### PR TITLE
Yuki - Add current milk price to the play page

### DIFF
--- a/frontend/src/main/components/Commons/CommonsOverview.js
+++ b/frontend/src/main/components/Commons/CommonsOverview.js
@@ -17,6 +17,7 @@ export default function CommonsOverview({ commons, currentUser }) {
                     <Col>
                         <Card.Title>Today is day {commons.day}! </Card.Title>
                         <Card.Text>Total Players: {commons.totalPlayers}</Card.Text>
+                        <Card.Text>Current milk price: ${commons.milkPrice}</Card.Text>
                     </Col>
                     <Col>
                         {showLeaderboard &&


### PR DESCRIPTION
In this PR, I added the current milk price to the play page under Announcements.

# Storybook

* [Before](https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-4/storybook/?path=/story/components-commons-commonsoverview--uncontrolled)
* [After](https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-4/prs/15/storybook/?path=/story/components-commons-commonsoverview--uncontrolled)

# Screenshots

Before

<img width="579" alt="image" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-4/assets/1119017/ca77c71d-c5f5-4be9-a661-57db62bf7ae0">


After

<img width="488" alt="image" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-4/assets/1119017/5e7aa7d9-0b63-4399-ba2e-7f9459850c84">

