### PR TITLE
Yuki - Fixed profits table overflow bug

### DIFF
--- a/frontend/src/main/components/Commons/CommonsOverview.js
+++ b/frontend/src/main/components/Commons/CommonsOverview.js
@@ -17,7 +17,6 @@ export default function CommonsOverview({ commons, currentUser }) {
                     <Col>
                         <Card.Title>Today is day {commons.day}! </Card.Title>
                         <Card.Text>Total Players: {commons.totalPlayers}</Card.Text>
-                        <Card.Text>Current milk price: ${commons.milkPrice}</Card.Text>
                     </Col>
                     <Col>
                         {showLeaderboard &&

--- a/frontend/src/main/components/Commons/CommonsOverview.js
+++ b/frontend/src/main/components/Commons/CommonsOverview.js
@@ -17,6 +17,7 @@ export default function CommonsOverview({ commons, currentUser }) {
                     <Col>
                         <Card.Title>Today is day {commons.day}! </Card.Title>
                         <Card.Text>Total Players: {commons.totalPlayers}</Card.Text>
+                        <Card.Text>Current milk price: ${commons.milkPrice}</Card.Text>
                     </Col>
                     <Col>
                         {showLeaderboard &&

--- a/frontend/src/main/components/Commons/ProfitsTable.js
+++ b/frontend/src/main/components/Commons/ProfitsTable.js
@@ -27,9 +27,19 @@ export default function ProfitsTable({ profits }) {
     const memoizedDates = React.useMemo(() => profits, [profits]);
     // Stryker enable ArrayDeclaration
 
-    return <OurTable
-        data={memoizedDates}
-        columns={memoizedColumns}
-        testid={"ProfitsTable"}
-    />;
+    
+    return (
+        <div 
+            style={ 
+                // Stryker disable next-line all: don't test CSS params
+                { overflow: "auto" } 
+            }
+        >
+            <OurTable
+                data={memoizedDates}
+                columns={memoizedColumns}
+                testid={"ProfitsTable"}
+            /> 
+        </div>
+    );
 };


### PR DESCRIPTION
In this PR, I fixed the profits table overflow bug. I added a horizontal scroll on overflow by wrapping the table in a div and changing the CSS overflow property of the div. (Closes #16)

Before 
![image](https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-4/assets/77693393/c05e37aa-82ee-46eb-bade-4d45007b774c)


After
![image](https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-4/assets/77693393/1adf0618-f6d5-415f-8697-746996146ba2)
