### PR TITLE
Yuki - Added total cows bought to play page and leaderboard table

### DIFF
--- a/frontend/src/fixtures/leaderboardFixtures.js
+++ b/frontend/src/fixtures/leaderboardFixtures.js
@@ -7,7 +7,8 @@ const leaderboardFixtures = {
             "username": "one",
             "commonsId": 1,
             "totalWealth" : 1000,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "totalCowsBought": 5
         }
     ],
     threeUserCommonsLB:
@@ -18,7 +19,8 @@ const leaderboardFixtures = {
             "username": "one",
             "commonsId": 1,
             "totalWealth" : 1000,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "totalCowsBought": 8
         },
         {
             "id":2,
@@ -26,7 +28,8 @@ const leaderboardFixtures = {
             "username": "two",
             "commonsId": 1,
             "totalWealth" : 1000,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "totalCowsBought": 5
         },
         {
             "id":3,
@@ -34,7 +37,8 @@ const leaderboardFixtures = {
             "username": "three",
             "commonsId": 1,
             "totalWealth" : 100000,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "totalCowsBought": 1000
         }
     ],
     fiveUserCommonsLB: 
@@ -46,7 +50,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "totalCowsBought": 8
         },
         {
             "id":2,
@@ -55,7 +60,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "totalCowsBought": 5
         },
         {
             "id":3,
@@ -64,7 +70,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "totalCowsBought": 1000
         },
         {
             "id":4,
@@ -73,7 +80,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "totalCowsBought": 100
         },
         {
             "id":5,
@@ -81,7 +89,8 @@ const leaderboardFixtures = {
             "username": "five",
             "commonsId": 1,
             "totalWealth" : 800,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "totalCowsBought": 60
         }
     ],
     tenUserCommonsLB: 
@@ -93,7 +102,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "totalCowsBought": 8
         },
         {
             "id":2,
@@ -102,7 +112,8 @@ const leaderboardFixtures = {
             "username": "two",
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "totalCowsBought": 5
         },
         {
             "id":3,
@@ -111,7 +122,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "totalCowsBought": 1000
         },
         {
             "id":4,
@@ -120,7 +132,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "totalCowsBought": 100
         },
         {
             "id":5,
@@ -129,7 +142,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 800,
             "cowHealth": 72.0,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "totalCowsBought": 60
         },
         {
             "id":6,
@@ -138,7 +152,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "totalCowsBought": 8
         },
         {
             "id":7,
@@ -147,7 +162,8 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "totalCowsBought": 5
         },
         {
             "id":8,
@@ -156,7 +172,8 @@ const leaderboardFixtures = {
             "commonsId":  1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "totalCowsBought": 1000
         },
         {
             "id":9,
@@ -165,7 +182,8 @@ const leaderboardFixtures = {
             "commonsId":  1,
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "totalCowsBought": 100
         },
         {
             "id":10,
@@ -173,7 +191,8 @@ const leaderboardFixtures = {
             "username": "ten",
             "commonsId": 1,
             "totalWealth" : 800,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "totalCowsBought": 60
         }
     ]
 }

--- a/frontend/src/fixtures/userCommonsFixtures.js
+++ b/frontend/src/fixtures/userCommonsFixtures.js
@@ -1,4 +1,14 @@
 const userCommonsFixtures = {
+    // Backend does not include "commons" or "user", so they probably shouldn't be in these fixtures
+    oneRealUserCommons: {
+        "id": 1,
+        "userId": 1,
+        "commonsId": 1,
+        "username": "idk if this field is even used",
+        "totalWealth": 1000,
+        "numOfCows": 5,
+        "cowHealth": 98.0
+    },
     oneUserCommons: 
     [
         {

--- a/frontend/src/fixtures/userCommonsFixtures.js
+++ b/frontend/src/fixtures/userCommonsFixtures.js
@@ -7,7 +7,8 @@ const userCommonsFixtures = {
         "username": "idk if this field is even used",
         "totalWealth": 1000,
         "numOfCows": 5,
-        "cowHealth": 98.0
+        "cowHealth": 98.0,
+        "totalCowsBought": 5,
     },
     oneUserCommons: 
     [
@@ -30,7 +31,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "totalCowsBought": 5,
         }
     ],
     threeUserCommons:
@@ -54,7 +56,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "totalCowsBought": 5,
         },
         {
             "id":2,
@@ -75,7 +78,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "totalCowsBought": 5,
         },
         {
             "id":3,
@@ -96,7 +100,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "totalCowsBought": 5,
         }
     ],
     fiveUserCommons: 
@@ -120,7 +125,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "totalCowsBought": 5,
         },
         {
             "id":2,
@@ -141,7 +147,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "totalCowsBought": 5,
         },
         {
             "id":3,
@@ -162,7 +169,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "totalCowsBought": 5,
         },
         {
             "id":4,
@@ -183,7 +191,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "totalCowsBought": 5,
         },
         {
             "id":5,
@@ -204,7 +213,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 800,
             "cowHealth": 72.0,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "totalCowsBought": 5,
         }
     ],
     tenUserCommons: 
@@ -228,7 +238,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "totalCowsBought": 5,
         },
         {
             "id":2,
@@ -249,7 +260,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "totalCowsBought": 5,
         },
         {
             "id":3,
@@ -270,7 +282,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "totalCowsBought": 5,
         },
         {
             "id":4,
@@ -291,7 +304,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "totalCowsBought": 5,
         },
         {
             "id":5,
@@ -312,7 +326,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 800,
             "cowHealth": 72.0,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "totalCowsBought": 5,
         },
         {
             "id":6,
@@ -333,7 +348,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "totalCowsBought": 5,
         },
         {
             "id":7,
@@ -354,7 +370,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "totalCowsBought": 5,
         },
         {
             "id":8,
@@ -375,7 +392,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "totalCowsBought": 5,
         },
         {
             "id":9,
@@ -396,7 +414,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "totalCowsBought": 5,
         },
         {
             "id":10,
@@ -417,7 +436,8 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 800,
             "cowHealth": 72.0,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "totalCowsBought": 5,
         }
     ]
 }

--- a/frontend/src/main/components/Commons/FarmStats.js
+++ b/frontend/src/main/components/Commons/FarmStats.js
@@ -21,6 +21,9 @@ const FarmStats = ({userCommons}) => {
             <Card.Text>
                 Cow Health: {Math.round(userCommons.cowHealth*100)/100}%
             </Card.Text>
+            <Card.Text>
+                Total Cows Bought: {userCommons.totalCowsBought}
+            </Card.Text>
         </Card.Body>
         </Card>
     ); 

--- a/frontend/src/main/components/Commons/ManageCows.js
+++ b/frontend/src/main/components/Commons/ManageCows.js
@@ -2,14 +2,16 @@ import React from "react";
 import { Card, Button, Row, Col } from "react-bootstrap";
 import cowHead from "./../../../assets/CowHead.png"; 
 
-// add parameters 
-const ManageCows = ({userCommons,commons, onBuy, onSell}) =>  {
+
+// add parameters
+const ManageCows = ({userCommons, commons, onBuy, onSell}) =>  {
     // update cowPrice from fixture
+    // Stryker disable ArithmeticOperator : line 24: not very important and unsure of how to test this
     return (
         <Card>
         <Card.Header as="h5">Manage Cows</Card.Header>
         <Card.Body>
-            {/* change $10 to info from fixture */}
+            {/* why does removing the optional chaining question mark turn the entire page white? */}
             <Card.Title>Market Cow Price: ${commons?.cowPrice}</Card.Title>
             <Card.Title>Number of Cows: {userCommons.numOfCows}</Card.Title>
                 <Row>
@@ -19,10 +21,22 @@ const ManageCows = ({userCommons,commons, onBuy, onSell}) =>  {
                         </Card.Text>
                     </Col>
                     <Col>
-                        <Button variant="outline-danger" onClick={()=>{onBuy(userCommons)}} data-testid={"buy-cow-button"}>Buy cow</Button>
+                        <Button variant="outline-danger" onClick={()=>{onBuy(userCommons, parseInt(userCommons.totalWealth/commons.cowPrice))}} data-testid={"buy-max-cows-button"}>Buy Max Cows</Button>
                         <br/>
                         <br/>
-                        <Button variant="outline-danger" onClick={()=>{onSell(userCommons)}} data-testid={"sell-cow-button"}>Sell cow</Button>
+                        <Button variant="outline-danger" onClick={()=>{onBuy(userCommons, 10)}} data-testid={"buy-10-cows-button"}>Buy 10 Cows</Button>
+                        <br/>
+                        <br/>
+                        <Button variant="outline-danger" onClick={()=>{onBuy(userCommons, 1)}} data-testid={"buy-a-cow-button"}>Buy a Cow</Button>
+                        <br/>
+                        <br/>
+                        <Button variant="outline-danger" onClick={()=>{onSell(userCommons, 1)}} data-testid={"sell-a-cow-button"}>Sell a Cow</Button>
+                        <br/>
+                        <br/>
+                        <Button variant="outline-danger" onClick={()=>{onSell(userCommons, 10)}} data-testid={"sell-10-cows-button"}>Sell 10 Cows</Button>
+                        <br/>
+                        <br/>
+                        <Button variant="outline-danger" onClick={()=>{onSell(userCommons, userCommons.numOfCows)}} data-testid={"sell-all-cows-button"}>Sell All Cows</Button>
                         <br/>
                         <br/>
                     </Col>

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -25,6 +25,10 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
             Header: 'Cow Health',
             accessor: 'cowHealth', 
         },
+        {
+            Header: 'Total Cows Bought',
+            accessor: 'totalCowsBought', 
+        },
     ];
 
     const testid = "LeaderboardTable";

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -32,7 +32,6 @@ export default function PlayPage() {
     );
   // Stryker enable all 
 
-
   // Stryker disable all 
   const { data: commons } =
     useBackend(
@@ -61,64 +60,52 @@ export default function PlayPage() {
     );
   // Stryker enable all 
 
-
   const onSuccessBuy = () => {
-    toast(`Cow bought!`);
+    toast(`Cows bought!`);
+  }
+  const onSuccessSell = () => {
+    toast(`Cows sold!`);
   }
 
-  const objectToAxiosParamsBuy = (newUserCommons) => ({
+  const onBuy = (userCommons, numToBuy) => {
+    mutationBuy.mutate({userCommons, numToBuy})
+  };
+  const onSell = (userCommons, numToSell) => {
+    mutationSell.mutate({userCommons, numToSell})
+  };
+
+  const objectToAxiosParamsBuy = ({newUserCommons, numToBuy}) => ({
     url: "/api/usercommons/buy",
     method: "PUT",
     data: newUserCommons,
     params: {
-      commonsId: commonsId
+      commonsId: commonsId,
+      numCows: numToBuy
     }
   });
-
-
-  // Stryker disable all 
-  const mutationbuy = useBackendMutation(
+  const mutationBuy = useBackendMutation(
     objectToAxiosParamsBuy,
     { onSuccess: onSuccessBuy },
     // Stryker disable next-line all : hard to set up test for caching
     [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`]
   );
-  // Stryker enable all 
 
-
-  const onBuy = (userCommons) => {
-    mutationbuy.mutate(userCommons)
-  };
-
-
-  const onSuccessSell = () => {
-    toast(`Cow sold!`);
-  }
-
-  // Stryker disable all 
-  const objectToAxiosParamsSell = (newUserCommons) => ({
+  const objectToAxiosParamsSell = ({newUserCommons, numToSell}) => ({
     url: "/api/usercommons/sell",
     method: "PUT",
     data: newUserCommons,
     params: {
-      commonsId: commonsId
+      commonsId: commonsId,
+      numCows: numToSell
     }
   });
-  // Stryker enable all 
-
-
-  // Stryker disable all 
-  const mutationsell = useBackendMutation(
+  const mutationSell = useBackendMutation(
     objectToAxiosParamsSell,
     { onSuccess: onSuccessSell },
+    // Stryker disable next-line all : hard to set up test for caching
     [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`]
   );
-  // Stryker enable all 
 
-
-  const onSell = (userCommons) => {
-    mutationsell.mutate(userCommons)
-  };
 
   return (
     <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>

--- a/frontend/src/tests/components/Commons/FarmStats.test.js
+++ b/frontend/src/tests/components/Commons/FarmStats.test.js
@@ -19,6 +19,7 @@ describe("FarmStats tests", () => {
         }); 
 
         expect(screen.getByText(/Cow Health: 98%/)).toBeInTheDocument();
+        expect(screen.getByText(/Total Cows Bought: 5/)).toBeInTheDocument();
 
     });
 });

--- a/frontend/src/tests/components/Commons/ManageCows.test.js
+++ b/frontend/src/tests/components/Commons/ManageCows.test.js
@@ -1,30 +1,43 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import ManageCows from "main/components/Commons/ManageCows"; 
 import userCommonsFixtures from "fixtures/userCommonsFixtures"; 
+import commonsFixtures from "fixtures/commonsFixtures";
 
 describe("ManageCows tests", () => {
+
     test("renders without crashing", () => {
         render(
             <ManageCows userCommons = {userCommonsFixtures.oneUserCommons[0]} onBuy={(userCommons) => { console.log("onBuy called:",userCommons); }} onSell={ (userCommons) => { console.log("onSell called:",userCommons); }} />
         );
     });
 
-    test("buying and selling a cow", async () => {
+    test("buying and selling cows", async () => {
         const mockBuy = jest.fn();
         const mockSell = jest.fn();
 
         render(
-            <ManageCows userCommons = {userCommonsFixtures.oneUserCommons[0]} onBuy={mockBuy} onSell={mockSell} />
+            <ManageCows userCommons = {userCommonsFixtures.oneUserCommons[0]} commons = {commonsFixtures.oneCommons[0]} onBuy={mockBuy} onSell={mockSell} />
         );
 
-        const buyButton = screen.getByTestId("buy-cow-button");
-        const sellButton = screen.getByTestId("sell-cow-button");
+        const buyMaxButton = screen.getByTestId("buy-max-cows-button");
+        const buyTenButton = screen.getByTestId("buy-10-cows-button");
+        const buyOneButton = screen.getByTestId("buy-a-cow-button");
+        const sellOneButton = screen.getByTestId("sell-a-cow-button");
+        const sellTenButton = screen.getByTestId("sell-10-cows-button");
+        const sellAllButton = screen.getByTestId("sell-all-cows-button");
         
-        fireEvent.click(buyButton);
-        await waitFor( ()=>expect(mockBuy).toHaveBeenCalled() );
-
-        fireEvent.click(sellButton);
-        await waitFor( ()=>expect(mockSell).toHaveBeenCalled() );
+        fireEvent.click(buyMaxButton);
+        await waitFor( ()=>expect(mockBuy).toHaveBeenCalled());
+        fireEvent.click(buyTenButton);
+        await waitFor( ()=>expect(mockBuy).toHaveBeenCalled());
+        fireEvent.click(buyOneButton);
+        await waitFor( ()=>expect(mockBuy).toHaveBeenCalled());
+        fireEvent.click(sellOneButton);
+        await waitFor( ()=>expect(mockSell).toHaveBeenCalled());
+        fireEvent.click(sellTenButton);
+        await waitFor( ()=>expect(mockSell).toHaveBeenCalled());
+        fireEvent.click(sellAllButton);
+        await waitFor( ()=>expect(mockSell).toHaveBeenCalled());
         
     });
 

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -65,8 +65,8 @@ describe("LeaderboardTable tests", () => {
 
     );
 
-    const expectedHeaders = ['(Admin) userCommons Id', 'Username', 'User Id', 'Total Wealth', 'Cows Owned', 'Cow Health'];
-    const expectedFields = ['id', 'userId', 'username', 'totalWealth','numOfCows', 'cowHealth'];
+    const expectedHeaders = ['(Admin) userCommons Id', 'Username', 'User Id', 'Total Wealth', 'Cows Owned', 'Cow Health', 'Total Cows Bought'];
+    const expectedFields = ['id', 'userId', 'username', 'totalWealth','numOfCows', 'cowHealth', 'totalCowsBought'];
     const testId = "LeaderboardTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -87,6 +87,7 @@ describe("LeaderboardTable tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-1-col-userId`)).toHaveTextContent("2");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-username`)).toHaveTextContent("two");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-totalWealth`)).toHaveTextContent("1000");
+    
 
   });
 

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -83,12 +83,14 @@ describe("LeaderboardTable tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-0-col-userId`)).toHaveTextContent("1");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-username`)).toHaveTextContent("one");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-totalWealth`)).toHaveTextContent("1000");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-totalCowsBought`)).toHaveTextContent("8");
+
     expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-userId`)).toHaveTextContent("2");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-username`)).toHaveTextContent("two");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-totalWealth`)).toHaveTextContent("1000");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-totalCowsBought`)).toHaveTextContent("5");
     
-
   });
 
 });

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -7,6 +7,8 @@ import AxiosMockAdapter from "axios-mock-adapter";
 import PlayPage from "main/pages/PlayPage";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import userCommonsFixtures from "fixtures/userCommonsFixtures";
+import commonsFixtures from "fixtures/commonsFixtures";
 
 jest.mock("react-router-dom", () => ({
     ...jest.requireActual("react-router-dom"),
@@ -20,30 +22,17 @@ describe("PlayPage tests", () => {
     const queryClient = new QueryClient();
 
     beforeEach(() => {
-        const userCommons = {
-            commonsId: 1,
-            id: 1,
-            totalWealth: 0,
-            userId: 1
-        };
         axiosMock.reset();
         axiosMock.resetHistory();
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/usercommons").reply(200, userCommonsFixtures.oneUserCommons);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-        axiosMock.onGet("/api/usercommons/forcurrentuser", { params: { commonsId: 1 } }).reply(200, userCommons);
-        axiosMock.onGet("/api/commons", { params: { id: 1 } }).reply(200, {
-            id: 1,
-            name: "Sample Commons"
-        });
-        axiosMock.onGet("/api/commons/all").reply(200, [
-            {
-                id: 1,
-                name: "Sample Commons"
-            }
-        ]);
+        axiosMock.onGet("/api/usercommons/forcurrentuser", { params: { commonsId: 1 } }).reply(200, userCommonsFixtures);
+        axiosMock.onGet("/api/commons", { params: { id: 1 } }).reply(200, commonsFixtures.oneCommons);
+        axiosMock.onGet("/api/commons/all").reply(200, commonsFixtures.sevenCommons);
         axiosMock.onGet("/api/profits/all/commonsid").reply(200, []);
-        axiosMock.onPut("/api/usercommons/sell").reply(200, userCommons);
-        axiosMock.onPut("/api/usercommons/buy").reply(200, userCommons);
+        axiosMock.onPut("/api/usercommons/sell").reply(200, userCommonsFixtures.oneUserCommons);
+        axiosMock.onPut("/api/usercommons/buy").reply(200, userCommonsFixtures.oneUserCommons);
     });
 
     test("renders without crashing", () => {
@@ -65,18 +54,62 @@ describe("PlayPage tests", () => {
             </QueryClientProvider>
         );
 
-        expect(await screen.findByTestId("buy-cow-button")).toBeInTheDocument();
-        const buyCowButton = screen.getByTestId("buy-cow-button");
-        fireEvent.click(buyCowButton);
+        expect(await screen.findByTestId("buy-a-cow-button")).toBeInTheDocument();
 
+        const buyMaxCowsButton = screen.getByTestId("buy-max-cows-button");
+        fireEvent.click(buyMaxCowsButton);
         await waitFor(() => expect(axiosMock.history.put.length).toBe(1));
-
-        const sellCowButton = screen.getByTestId("sell-cow-button");
-        fireEvent.click(sellCowButton);
-
+        const buyTenCowsButton = screen.getByTestId("buy-10-cows-button");
+        fireEvent.click(buyTenCowsButton);
         await waitFor(() => expect(axiosMock.history.put.length).toBe(2));
+        const buyCowButton = screen.getByTestId("buy-a-cow-button");
+        fireEvent.click(buyCowButton);
+        await waitFor(() => expect(axiosMock.history.put.length).toBe(3));
+
+        const sellCowButton = screen.getByTestId("sell-a-cow-button");
+        fireEvent.click(sellCowButton);
+        await waitFor(() => expect(axiosMock.history.put.length).toBe(4));
+        const sellTenCowsButton = screen.getByTestId("sell-10-cows-button");
+        fireEvent.click(sellTenCowsButton);
+        await waitFor(() => expect(axiosMock.history.put.length).toBe(5));
+        const sellAllCowsButton = screen.getByTestId("sell-all-cows-button");
+        fireEvent.click(sellAllCowsButton);
+        await waitFor(() => expect(axiosMock.history.put.length).toBe(6));
     });
 
+    // Not sure how to test this since I'm unable to call the onBuy and onSell functions from PlayPage
+/*  test("test buy and sell buttons work properly", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlayPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        const buyMaxButton = screen.getByTestId("buy-max-cows-button");
+        const buyTenButton = screen.getByTestId("buy-10-cows-button");
+        const buyOneButton = screen.getByTestId("buy-a-cow-button");
+        const sellOneButton = screen.getByTestId("sell-a-cow-button");
+        const sellTenButton = screen.getByTestId("sell-10-cows-button");
+        const sellAllButton = screen.getByTestId("sell-all-cows-button");
+        
+        fireEvent.click(buyMaxButton);
+        await waitFor( ()=>expect(onBuy).toContain(userCommonsFixtures.oneRealUserCommons, 50));
+        fireEvent.click(buyTenButton);
+        await waitFor( ()=>expect(onBuy).toHaveBeenCalled());
+        fireEvent.click(buyOneButton);
+        await waitFor( ()=>expect(onBuy).toHaveBeenCalled());
+        fireEvent.click(sellOneButton);
+        await waitFor( ()=>expect(onSell).toHaveBeenCalled());
+        fireEvent.click(sellTenButton);
+        await waitFor( ()=>expect(onSell).toHaveBeenCalled());
+        fireEvent.click(sellAllButton);
+        await waitFor( ()=>expect(onSell).toHaveBeenCalled());
+
+    });
+*/
+    
     test("Make sure that both the Announcements and Welcome Farmer components show up", async () => {
         render(
             <QueryClientProvider client={queryClient}>

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -190,6 +190,7 @@ public class CommonsController extends ApiController {
         .totalWealth(joinedCommons.getStartingBalance())
         .numOfCows(0)
         .cowHealth(100)
+        .totalCowsBought(0)
         .build();
 
     userCommonsRepository.save(uc);

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -90,6 +90,7 @@ public class UserCommonsController extends ApiController {
         if(userCommons.getTotalWealth() >= commons.getCowPrice() ){
           userCommons.setTotalWealth(userCommons.getTotalWealth() - commons.getCowPrice());
           userCommons.setNumOfCows(userCommons.getNumOfCows() + 1);
+          userCommons.setTotalCowsBought(userCommons.getTotalCowsBought() + 1);
         }
         else{
           throw new NotEnoughMoneyException("You need more money!");

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/UserCommons.java
@@ -33,5 +33,7 @@ public class UserCommons {
   private int numOfCows;
 
   private double cowHealth;
+
+  private int totalCowsBought;
 }
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -45,769 +45,892 @@ import java.time.LocalDateTime;
 @AutoConfigureDataJpa
 public class UserCommonsControllerTests extends ControllerTestCase {
 
-  @MockBean
-  UserCommonsRepository userCommonsRepository;
+    @MockBean
+    UserCommonsRepository userCommonsRepository;
 
-  @MockBean
-  UserRepository userRepository;
+    @MockBean
+    UserRepository userRepository;
 
-  @MockBean
-  CommonsRepository commonsRepository;
+    @MockBean
+    CommonsRepository commonsRepository;
 
-  @Autowired
-  private ObjectMapper objectMapper;
+    @Autowired
+    private ObjectMapper objectMapper;
 
-  public static UserCommons dummyUserCommons(long id) {
-    UserCommons userCommons = new UserCommons(id,1,1,"test",1,1, 100,1);
-    return userCommons;
-  }
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void test_getUserCommonsById_exists_admin() throws Exception {
-  
-    UserCommons expectedUserCommons = dummyUserCommons(1);
-    when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L),eq(1L))).thenReturn(Optional.of(expectedUserCommons));
-
-    MvcResult response = mockMvc.perform(get("/api/usercommons/?userId=1&commonsId=1"))
-        .andExpect(status().isOk()).andReturn();
-
-    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L),eq(1L));
-
-    String expectedJson = mapper.writeValueAsString(expectedUserCommons);
-    String responseString = response.getResponse().getContentAsString();
-
-    assertEquals(expectedJson, responseString);
-  }
-  
-  @WithMockUser(roles = { "ADMIN" })
-  @Test
-  public void test_getUserCommonsById_nonexists_admin() throws Exception {
-  
-    when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L),eq(1L))).thenReturn(Optional.empty());
-
-    MvcResult response = mockMvc.perform(get("/api/usercommons/?userId=1&commonsId=1"))
-        .andExpect(status().is(404)).andReturn();
-
-    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L),eq(1L));
-    
-    String responseString = response.getResponse().getContentAsString();
-    String expectedString = "{\"message\":\"UserCommons with commonsId 1 and userId 1 not found\",\"type\":\"EntityNotFoundException\"}";
-
-    Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
-    Map<String, Object> jsonResponse = responseToJson(response);
-    assertEquals(expectedJson, jsonResponse);
-  }
-
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void test_getUserCommonsById_exists() throws Exception {
-  
-    UserCommons expectedUserCommons = dummyUserCommons(1);
-    when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L),eq(1L))).thenReturn(Optional.of(expectedUserCommons));
-
-    MvcResult response = mockMvc.perform(get("/api/usercommons/forcurrentuser?commonsId=1"))
-        .andExpect(status().isOk()).andReturn();
-
-    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L),eq(1L));
-
-    String expectedJson = mapper.writeValueAsString(expectedUserCommons);
-    String responseString = response.getResponse().getContentAsString();
-
-    assertEquals(expectedJson, responseString);
-  }
-  
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void test_getUserCommonsById_nonexists() throws Exception {
-  
-    when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L),eq(1L))).thenReturn(Optional.empty());
-
-    MvcResult response = mockMvc.perform(get("/api/usercommons/forcurrentuser?commonsId=1"))
-        .andExpect(status().is(404)).andReturn();
-
-    verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L),eq(1L));
-    
-    String responseString = response.getResponse().getContentAsString();
-    String expectedString = "{\"message\":\"UserCommons with commonsId 1 and userId 1 not found\",\"type\":\"EntityNotFoundException\"}";
-    Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
-    Map<String, Object> jsonResponse = responseToJson(response);
-    assertEquals(expectedJson, jsonResponse);
-  }
-
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void test_BuyCow_commons_exists() throws Exception {
-  
-      // arrange
-  
-      UserCommons origUserCommons = UserCommons
-            .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .cowHealth(100)
-      .totalCowsBought(1)
-      .build();
-  
-      Commons testCommons = Commons
-      .builder()
-      .name("test commons")
-      .cowPrice(10)
-      .milkPrice(2)
-      .startingBalance(300)
-      .startingDate(LocalDateTime.now())
-      .build();
-  
-      UserCommons userCommonsToSend = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .cowHealth(100)
-      .totalCowsBought(1)
-      .build();
-  
-      UserCommons correctuserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300-testCommons.getCowPrice())
-      .numOfCows(2)
-      .cowHealth(100)
-      .totalCowsBought(2)
-      .build();
-  
-      String requestBody = mapper.writeValueAsString(userCommonsToSend);
-      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
-  
-      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
-      when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
-  
-      // act
-      MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=1")
-          .contentType(MediaType.APPLICATION_JSON)
-                      .characterEncoding("utf-8")
-                      .content(requestBody)
-                      .with(csrf()))
-              .andExpect(status().isOk()).andReturn();
-  
-      // assert
-      verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
-      verify(userCommonsRepository, times(1)).save(correctuserCommons);
-      String responseString = response.getResponse().getContentAsString();
-      assertEquals(expectedReturn, responseString);
-  }
-
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void test_BuyCow_commons_exists_user_has_exact_amount_needed() throws Exception {
-  
-      // arrange
-  
-      UserCommons origUserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .cowHealth(100)
-      .totalCowsBought(1)
-      .build();
-  
-      Commons testCommons = Commons
-      .builder()
-      .name("test commons")
-      .cowPrice(300)
-      .milkPrice(2)
-      .startingBalance(300)
-      .startingDate(LocalDateTime.now())
-      .build();
-  
-      UserCommons userCommonsToSend = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .cowHealth(100)
-      .totalCowsBought(1)
-      .build();
-  
-      UserCommons correctuserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(0)
-      .numOfCows(2)
-      .cowHealth(100)
-      .totalCowsBought(2)
-      .build();
-  
-      String requestBody = mapper.writeValueAsString(userCommonsToSend);
-      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
-  
-      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
-      when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
-  
-      // act
-      MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=1")
-          .contentType(MediaType.APPLICATION_JSON)
-                      .characterEncoding("utf-8")
-                      .content(requestBody)
-                      .with(csrf()))
-              .andExpect(status().isOk()).andReturn();
-  
-      // assert
-      verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
-      verify(userCommonsRepository, times(1)).save(correctuserCommons);
-      String responseString = response.getResponse().getContentAsString();
-      assertEquals(expectedReturn, responseString);
-  }
-  
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void test_SellCow_commons_exists() throws Exception {
-  
-      // arrange
-  
-      UserCommons origUserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .cowHealth(100)
-      .totalCowsBought(1)
-      .build();
-  
-      Commons testCommons = Commons
-      .builder()
-      .name("test commons")
-      .cowPrice(10)
-      .milkPrice(2)
-      .startingBalance(300)
-      .startingDate(LocalDateTime.now())
-      .build();
-  
-      UserCommons userCommonsToSend = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .cowHealth(100)
-      .totalCowsBought(1)
-      .build();
-  
-      UserCommons correctuserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300+testCommons.getCowPrice())
-      .numOfCows(0)
-      .cowHealth(100)
-      .totalCowsBought(1)
-      .build();
-  
-      String requestBody = mapper.writeValueAsString(userCommonsToSend);
-      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
-  
-      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
-      when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
-  
-      // act
-      MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=1")
-          .contentType(MediaType.APPLICATION_JSON)
-                      .characterEncoding("utf-8")
-                      .content(requestBody)
-                      .with(csrf()))
-              .andExpect(status().isOk()).andReturn();
-  
-      // assert
-      verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
-      verify(userCommonsRepository, times(1)).save(correctuserCommons);
-      String responseString = response.getResponse().getContentAsString();
-      assertEquals(expectedReturn, responseString);
-  }
-  
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void test_BuyCow_commons_for_user_DOES_NOT_exist() throws Exception {
-  
-      // arrange
-  
-      UserCommons origUserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .cowHealth(100)
-      .totalCowsBought(1)
-      .build();
-  
-      Commons testCommons = Commons
-      .builder()
-      .name("test commons")
-      .cowPrice(10)
-      .milkPrice(2)
-      .startingBalance(300)
-      .startingDate(LocalDateTime.now())
-      .build();
-  
-      UserCommons userCommonsToSend = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .cowHealth(100)
-      .totalCowsBought(1)
-      .build();
-  
-      UserCommons correctuserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300-testCommons.getCowPrice())
-      .numOfCows(2)
-      .cowHealth(100)
-      .totalCowsBought(2)
-      .build();
-  
-      String requestBody = mapper.writeValueAsString(userCommonsToSend);
-      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
-  
-      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
-      when(commonsRepository.findById(eq(234L))).thenReturn(Optional.of(testCommons));
-  
-      // act
-      MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=234") 
-          .contentType(MediaType.APPLICATION_JSON)
-                      .characterEncoding("utf-8")
-                      .content(requestBody)
-                      .with(csrf()))
-              .andExpect(status().is(404)).andReturn();
-  
-      // assert
-  
-      String responseString = response.getResponse().getContentAsString();
-      String expectedString = "{\"message\":\"UserCommons with commonsId 234 and userId 1 not found\",\"type\":\"EntityNotFoundException\"}";
-      Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
-      Map<String, Object> jsonResponse = responseToJson(response);
-      assertEquals(expectedJson, jsonResponse);
-  }
-  
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void test_SellCow_commons_for_usercommons_DOES_NOT_exist() throws Exception {
-  
-      // arrange
-  
-      UserCommons origUserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .cowHealth(100)
-      .totalCowsBought(1)
-      .build();
-  
-      Commons testCommons = Commons
-      .builder()
-      .id(234L)
-      .name("test commons")
-      .cowPrice(10)
-      .milkPrice(2)
-      .startingBalance(300)
-      .startingDate(LocalDateTime.now())
-      .build();
-  
-      UserCommons userCommonsToSend = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .cowHealth(100)
-      .totalCowsBought(1)
-      .build();
-  
-      UserCommons correctuserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300+testCommons.getCowPrice())
-      .numOfCows(2)
-      .cowHealth(100)
-      .totalCowsBought(2)
-      .build();
-  
-      String requestBody = mapper.writeValueAsString(userCommonsToSend);
-      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
-  
-      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
-      when(commonsRepository.findById(eq(234L))).thenReturn(Optional.of(testCommons));
-  
-      // act
-      MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=234")
-          .contentType(MediaType.APPLICATION_JSON)
-                      .characterEncoding("utf-8")
-                      .content(requestBody)
-                      .with(csrf()))
-              .andExpect(status().is(404)).andReturn();
-  
-      // assert
-      String responseString = response.getResponse().getContentAsString();
-      String expectedString = "{\"message\":\"UserCommons with commonsId 234 and userId 1 not found\",\"type\":\"EntityNotFoundException\"}";
-      Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
-      Map<String, Object> jsonResponse = responseToJson(response);
-      assertEquals(expectedJson, jsonResponse);
-  }
-  
-  //tests for when the common itself doesn't exist
-  
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void test_SellCow_commons_DOES_NOT_exist() throws Exception {
-  
-      // arrange
-  
-      UserCommons origUserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .cowHealth(100)
-      .totalCowsBought(1)
-      .build();
-  
-      Commons testCommons = Commons
-      .builder()
-      .name("test commons")
-      .cowPrice(10)
-      .milkPrice(2)
-      .startingBalance(300)
-      .startingDate(LocalDateTime.now())
-      .build();
-  
-      UserCommons userCommonsToSend = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .cowHealth(100)
-      .totalCowsBought(1)
-      .build();
-  
-      UserCommons correctuserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300+testCommons.getCowPrice())
-      .numOfCows(2)
-      .cowHealth(100)
-      .totalCowsBought(2)
-      .build();
-  
-      String requestBody = mapper.writeValueAsString(userCommonsToSend);
-      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
-  
-      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
-      when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
-  
-      // act
-      MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=222")
-          .contentType(MediaType.APPLICATION_JSON)
-                      .characterEncoding("utf-8")
-                      .content(requestBody)
-                      .with(csrf()))
-              .andExpect(status().is(404)).andReturn();
-  
-      // assert
-      String responseString = response.getResponse().getContentAsString();
-      String expectedString = "{\"message\":\"Commons with id 222 not found\",\"type\":\"EntityNotFoundException\"}";
-      Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
-      Map<String, Object> jsonResponse = responseToJson(response);
-      assertEquals(expectedJson, jsonResponse);
-  }
-  
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void test_BuyCow_commons_DOES_NOT_exist() throws Exception {
-  
-      // arrange
-  
-      UserCommons origUserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .cowHealth(100)
-      .totalCowsBought(1)
-      .build();
-  
-      Commons testCommons = Commons
-      .builder()
-      .name("test commons")
-      .cowPrice(10)
-      .milkPrice(2)
-      .startingBalance(300)
-      .startingDate(LocalDateTime.now())
-      .build();
-  
-      UserCommons userCommonsToSend = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(1)
-      .cowHealth(100)
-      .totalCowsBought(1)
-      .build();
-  
-      UserCommons correctuserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300+testCommons.getCowPrice())
-      .numOfCows(2)
-      .cowHealth(100)
-      .totalCowsBought(2)
-      .build();
-  
-      String requestBody = mapper.writeValueAsString(userCommonsToSend);
-      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
-  
-      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
-      when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
-  
-      // act
-      MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=222")
-          .contentType(MediaType.APPLICATION_JSON)
-                      .characterEncoding("utf-8")
-                      .content(requestBody)
-                      .with(csrf()))
-              .andExpect(status().is(404)).andReturn();
-  
-      // assert
-      String responseString = response.getResponse().getContentAsString();
-      String expectedString = "{\"message\":\"Commons with id 222 not found\",\"type\":\"EntityNotFoundException\"}";
-      Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
-      Map<String, Object> jsonResponse = responseToJson(response);
-      assertEquals(expectedJson, jsonResponse);
-  }
-  
-  
-  
-  // Put tests for edge cases (not enough money to buy, or no cow to sell)
-  
-  
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void test_BuyCow_commons_exists_not_enough_money() throws Exception {
-  
-      // arrange
-  
-      UserCommons origUserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(0)
-      .numOfCows(1)
-      .cowHealth(100)
-      .totalCowsBought(1)
-      .build();
-  
-      Commons testCommons = Commons
-      .builder()
-      .name("test commons")
-      .cowPrice(10)
-      .milkPrice(2)
-      .startingBalance(0)
-      .startingDate(LocalDateTime.now())
-      .build();
-  
-      UserCommons userCommonsToSend = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(0)
-      .numOfCows(1)
-      .cowHealth(100)
-      .totalCowsBought(1)
-      .build();
-  
-      UserCommons correctuserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(0)
-      .numOfCows(1)
-      .cowHealth(100)
-      .totalCowsBought(1)
-      .build();
-  
-      String requestBody = mapper.writeValueAsString(userCommonsToSend);
-      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
-  
-      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
-      when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
-  
-      // act
-      MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=1")
-          .contentType(MediaType.APPLICATION_JSON)
-                      .characterEncoding("utf-8")
-                      .content(requestBody)
-                      .with(csrf()))
-              .andExpect(status().is(400)).andReturn();
-  
-      // assert
-      String responseString = response.getResponse().getContentAsString();
-      String expectedString = "{\"message\":\"You need more money!\",\"type\":\"NotEnoughMoneyException\"}";
-      Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
-      Map<String, Object> jsonResponse = responseToJson(response);
-      assertEquals(expectedJson, jsonResponse);
-  }
-  
-  @WithMockUser(roles = { "USER" })
-  @Test
-  public void test_SellCow_commons_exists_no_cow_to_sell() throws Exception {
-  
-      // arrange
-  
-      UserCommons origUserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(0)
-      .cowHealth(100)
-      .totalCowsBought(0)
-      .build();
-  
-      Commons testCommons = Commons
-      .builder()
-      .name("test commons")
-      .cowPrice(10)
-      .milkPrice(2)
-      .startingBalance(300)
-      .startingDate(LocalDateTime.now())
-      .build();
-  
-      UserCommons userCommonsToSend = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(0)
-      .cowHealth(100)
-      .totalCowsBought(0)
-      .build();
-  
-      UserCommons correctuserCommons = UserCommons
-      .builder()
-      .id(1L)
-      .userId(1L)
-      .commonsId(1L)
-      .totalWealth(300)
-      .numOfCows(0)
-      .cowHealth(100)
-      .totalCowsBought(0)
-      .build();
-  
-      String requestBody = mapper.writeValueAsString(userCommonsToSend);
-      String expectedReturn = mapper.writeValueAsString(correctuserCommons);
-  
-      when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
-      when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
-  
-      // act
-      MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=1")
-          .contentType(MediaType.APPLICATION_JSON)
-                      .characterEncoding("utf-8")
-                      .content(requestBody)
-                      .with(csrf())).andExpect(status().is(400)).andReturn();
-
-
-      // assert
-      String responseString = response.getResponse().getContentAsString();
-      String expectedString = "{\"message\":\"You have no cows to sell!\",\"type\":\"NoCowsException\"}";
-      Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
-      Map<String, Object> jsonResponse = responseToJson(response);
-      assertEquals(expectedJson, jsonResponse);
-    
+    public static UserCommons dummyUserCommons(long id) {
+        UserCommons userCommons = new UserCommons(id,1,1,"test",1,1, 100,1);
+        return userCommons;
     }
 
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void test_getUserCommonsById_exists_admin() throws Exception {
+    
+        UserCommons expectedUserCommons = dummyUserCommons(1);
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L),eq(1L))).thenReturn(Optional.of(expectedUserCommons));
+
+        MvcResult response = mockMvc.perform(get("/api/usercommons/?userId=1&commonsId=1"))
+            .andExpect(status().isOk()).andReturn();
+
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L),eq(1L));
+
+        String expectedJson = mapper.writeValueAsString(expectedUserCommons);
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(expectedJson, responseString);
+    }
+    
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void test_getUserCommonsById_nonexists_admin() throws Exception {
+    
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L),eq(1L))).thenReturn(Optional.empty());
+
+        MvcResult response = mockMvc.perform(get("/api/usercommons/?userId=1&commonsId=1"))
+            .andExpect(status().is(404)).andReturn();
+
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L),eq(1L));
+        
+        String responseString = response.getResponse().getContentAsString();
+        String expectedString = "{\"message\":\"UserCommons with commonsId 1 and userId 1 not found\",\"type\":\"EntityNotFoundException\"}";
+
+        Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+        Map<String, Object> jsonResponse = responseToJson(response);
+        assertEquals(expectedJson, jsonResponse);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_getUserCommonsById_exists() throws Exception {
+    
+        UserCommons expectedUserCommons = dummyUserCommons(1);
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L),eq(1L))).thenReturn(Optional.of(expectedUserCommons));
+
+        MvcResult response = mockMvc.perform(get("/api/usercommons/forcurrentuser?commonsId=1"))
+            .andExpect(status().isOk()).andReturn();
+
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L),eq(1L));
+
+        String expectedJson = mapper.writeValueAsString(expectedUserCommons);
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(expectedJson, responseString);
+    }
+    
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_getUserCommonsById_nonexists() throws Exception {
+    
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L),eq(1L))).thenReturn(Optional.empty());
+
+        MvcResult response = mockMvc.perform(get("/api/usercommons/forcurrentuser?commonsId=1"))
+            .andExpect(status().is(404)).andReturn();
+
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L),eq(1L));
+        
+        String responseString = response.getResponse().getContentAsString();
+        String expectedString = "{\"message\":\"UserCommons with commonsId 1 and userId 1 not found\",\"type\":\"EntityNotFoundException\"}";
+        Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+        Map<String, Object> jsonResponse = responseToJson(response);
+        assertEquals(expectedJson, jsonResponse);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_BuyCow_commons_exists() throws Exception {
+    
+        // arrange
+        UserCommons origUserCommons = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(300)
+            .numOfCows(1)
+            .cowHealth(100)
+            .totalCowsBought(1)
+            .build();
+
+        Commons testCommons = Commons
+            .builder()
+            .name("test commons")
+            .cowPrice(10)
+            .milkPrice(2)
+            .startingBalance(300)
+            .startingDate(LocalDateTime.now())
+            .build();
+
+        UserCommons userCommonsToSend = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(300)
+            .numOfCows(1)
+            .cowHealth(100)
+            .totalCowsBought(1)
+            .build();
+
+        UserCommons correctuserCommons = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(300-testCommons.getCowPrice())
+            .numOfCows(2)
+            .cowHealth(100)
+            .totalCowsBought(2)
+            .build();
+    
+        String requestBody = mapper.writeValueAsString(userCommonsToSend);
+        String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+    
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+        when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
+    
+        // act
+        MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=1&numCows=1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8")
+            .content(requestBody)
+            .with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+    
+        // assert
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
+        verify(userCommonsRepository, times(1)).save(correctuserCommons);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedReturn, responseString);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_BuyCow_commons_exists_user_has_exact_amount_needed() throws Exception {
+    
+        // arrange
+        UserCommons origUserCommons = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(600)
+            .numOfCows(1)
+            .cowHealth(100)
+            .totalCowsBought(1)
+            .build();
+
+        Commons testCommons = Commons
+            .builder()
+            .name("test commons")
+            .cowPrice(300)
+            .milkPrice(2)
+            .startingBalance(300)
+            .startingDate(LocalDateTime.now())
+            .build();
+
+        UserCommons userCommonsToSend = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(600)
+            .numOfCows(1)
+            .cowHealth(100)
+            .totalCowsBought(1)
+            .build();
+
+        UserCommons correctuserCommons = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(0)
+            .numOfCows(3)
+            .cowHealth(100)
+            .totalCowsBought(3)
+            .build();
+    
+        String requestBody = mapper.writeValueAsString(userCommonsToSend);
+        String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+    
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+        when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
+    
+        // act
+        MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=1&numCows=2")
+            .contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8")
+            .content(requestBody)
+            .with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+    
+        // assert
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
+        verify(userCommonsRepository, times(1)).save(correctuserCommons);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedReturn, responseString);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_SellCow_commons_exists() throws Exception {
+    
+        // arrange
+        UserCommons origUserCommons = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(300)
+            .numOfCows(1)
+            .cowHealth(100) 
+            .totalCowsBought(1)
+            .build();
+
+        Commons testCommons = Commons
+            .builder()
+            .name("test commons")
+            .cowPrice(10)
+            .milkPrice(2)
+            .startingBalance(300)
+            .startingDate(LocalDateTime.now())
+            .build();
+
+        UserCommons userCommonsToSend = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(300)
+            .numOfCows(1)
+            .cowHealth(100)
+            .totalCowsBought(1)
+            .build();
+
+        UserCommons correctuserCommons = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(300+testCommons.getCowPrice())
+            .numOfCows(0)
+            .cowHealth(100)
+            .totalCowsBought(1)
+            .build();
+
+        String requestBody = mapper.writeValueAsString(userCommonsToSend);
+        String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+        when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
+
+        // act
+        MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=1&numCows=1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8")
+            .content(requestBody)
+            .with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
+        verify(userCommonsRepository, times(1)).save(correctuserCommons);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedReturn, responseString);
+    }
+    
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_BuyCow_commons_for_user_DOES_NOT_exist() throws Exception {
+
+        // arrange
+        UserCommons origUserCommons = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(300)
+            .numOfCows(1)
+            .cowHealth(100)
+            .totalCowsBought(1)
+            .build();
+
+        Commons testCommons = Commons
+            .builder()
+            .name("test commons")
+            .cowPrice(10)
+            .milkPrice(2)
+            .startingBalance(300)
+            .startingDate(LocalDateTime.now())
+            .build();
+
+        UserCommons userCommonsToSend = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(300)
+            .numOfCows(1)
+            .cowHealth(100)
+            .totalCowsBought(1)
+            .build();
+
+        UserCommons correctuserCommons = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(300-testCommons.getCowPrice())
+            .numOfCows(2)
+            .cowHealth(100)
+            .totalCowsBought(2)
+            .build();
+
+        String requestBody = mapper.writeValueAsString(userCommonsToSend);
+        String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+        when(commonsRepository.findById(eq(234L))).thenReturn(Optional.of(testCommons));
+
+        // act
+        MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=234&numCows=1") 
+            .contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8")
+            .content(requestBody)
+            .with(csrf()))
+            .andExpect(status().is(404)).andReturn();
+
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        String expectedString = "{\"message\":\"UserCommons with commonsId 234 and userId 1 not found\",\"type\":\"EntityNotFoundException\"}";
+        Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+        Map<String, Object> jsonResponse = responseToJson(response);
+        assertEquals(expectedJson, jsonResponse);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_SellCow_commons_for_usercommons_DOES_NOT_exist() throws Exception {
+    
+        // arrange
+        UserCommons origUserCommons = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(300)
+            .numOfCows(1)
+            .cowHealth(100)
+            .totalCowsBought(1)
+            .build();
+
+        Commons testCommons = Commons
+            .builder()
+            .id(234L)
+            .name("test commons")
+            .cowPrice(10)
+            .milkPrice(2)
+            .startingBalance(300)
+            .startingDate(LocalDateTime.now())
+            .build();
+
+        UserCommons userCommonsToSend = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(300)
+            .numOfCows(1)
+            .cowHealth(100)
+            .totalCowsBought(1)
+            .build();
+
+        UserCommons correctuserCommons = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(300+testCommons.getCowPrice())
+            .numOfCows(2)
+            .cowHealth(100)
+            .totalCowsBought(2)
+            .build();
+
+        String requestBody = mapper.writeValueAsString(userCommonsToSend);
+        String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+        when(commonsRepository.findById(eq(234L))).thenReturn(Optional.of(testCommons));
+
+        // act
+        MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=234&numCows=1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8")
+            .content(requestBody)
+            .with(csrf()))
+            .andExpect(status().is(404)).andReturn();
+
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        String expectedString = "{\"message\":\"UserCommons with commonsId 234 and userId 1 not found\",\"type\":\"EntityNotFoundException\"}";
+        Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+        Map<String, Object> jsonResponse = responseToJson(response);
+        assertEquals(expectedJson, jsonResponse);
+    }
+    
+    //tests for when the common itself doesn't exist
+    
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_SellCow_commons_DOES_NOT_exist() throws Exception {
+    
+        // arrange
+        UserCommons origUserCommons = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(300)
+            .numOfCows(1)
+            .cowHealth(100)
+            .totalCowsBought(1)
+            .build();
+
+        Commons testCommons = Commons
+            .builder()
+            .name("test commons")
+            .cowPrice(10)
+            .milkPrice(2)
+            .startingBalance(300)
+            .startingDate(LocalDateTime.now())
+            .build();
+
+        UserCommons userCommonsToSend = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(300)
+            .numOfCows(1)
+            .cowHealth(100)
+            .totalCowsBought(1)
+            .build();
+
+        UserCommons correctuserCommons = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(300+testCommons.getCowPrice())
+            .numOfCows(2)
+            .cowHealth(100)
+            .totalCowsBought(2)
+            .build();
+
+        String requestBody = mapper.writeValueAsString(userCommonsToSend);
+        String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+        when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
+
+        // act
+        MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=222&numCows=1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8")
+            .content(requestBody)
+            .with(csrf()))
+            .andExpect(status().is(404)).andReturn();
+
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        String expectedString = "{\"message\":\"Commons with id 222 not found\",\"type\":\"EntityNotFoundException\"}";
+        Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+        Map<String, Object> jsonResponse = responseToJson(response);
+        assertEquals(expectedJson, jsonResponse);
+    }
+    
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_BuyCow_commons_DOES_NOT_exist() throws Exception {
+    
+        // arrange
+        UserCommons origUserCommons = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(300)
+            .numOfCows(1)
+            .cowHealth(100)
+            .totalCowsBought(1)
+            .build();
+
+        Commons testCommons = Commons
+            .builder()
+            .name("test commons")
+            .cowPrice(10)
+            .milkPrice(2)
+            .startingBalance(300)
+            .startingDate(LocalDateTime.now())
+            .build();
+
+        UserCommons userCommonsToSend = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(300)
+            .numOfCows(1)
+            .cowHealth(100)
+            .totalCowsBought(1)
+            .build();
+
+        UserCommons correctuserCommons = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(300+testCommons.getCowPrice())
+            .numOfCows(2)
+            .cowHealth(100)
+            .totalCowsBought(1)
+            .build();
+
+        String requestBody = mapper.writeValueAsString(userCommonsToSend);
+        String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+        when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
+
+        // act
+        MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=222&numCows=1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8")
+            .content(requestBody)
+            .with(csrf()))
+            .andExpect(status().is(404)).andReturn();
+
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        String expectedString = "{\"message\":\"Commons with id 222 not found\",\"type\":\"EntityNotFoundException\"}";
+        Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+        Map<String, Object> jsonResponse = responseToJson(response);
+        assertEquals(expectedJson, jsonResponse);
+    }
+    
+
+    // Put tests for edge cases (not enough money to buy, or no cow to sell)
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_BuyCow_commons_exists_not_enough_money() throws Exception {
+    
+        // arrange
+        UserCommons origUserCommons = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(10)
+            .numOfCows(1)
+            .cowHealth(100)
+            .totalCowsBought(1)
+            .build();
+
+        Commons testCommons = Commons
+            .builder()
+            .name("test commons")
+            .cowPrice(10)
+            .milkPrice(2)
+            .startingBalance(0)
+            .startingDate(LocalDateTime.now())
+            .build();
+
+        UserCommons userCommonsToSend = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(10)
+            .numOfCows(1)
+            .cowHealth(100)
+            .totalCowsBought(1)
+            .build();
+
+        UserCommons correctuserCommons = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(10)
+            .numOfCows(1)
+            .cowHealth(100)
+            .totalCowsBought(1)
+            .build();
+
+        String requestBody = mapper.writeValueAsString(userCommonsToSend);
+        String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+        when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
+
+        // act
+        MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=1&numCows=2")
+            .contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8")
+            .content(requestBody)
+            .with(csrf()))
+            .andExpect(status().is(400)).andReturn();
+
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        String expectedString = "{\"message\":\"You need more money!\",\"type\":\"NotEnoughMoneyException\"}";
+        Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+        Map<String, Object> jsonResponse = responseToJson(response);
+        assertEquals(expectedJson, jsonResponse);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_BuyCow_commons_exists_try_to_buy_zero_cows() throws Exception {
+    
+        // arrange
+        UserCommons origUserCommons = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(100)
+            .numOfCows(1)
+            .cowHealth(100)
+            .totalCowsBought(1)
+            .build();
+
+        Commons testCommons = Commons
+            .builder()
+            .name("test commons")
+            .cowPrice(10)
+            .milkPrice(2)
+            .startingBalance(0)
+            .startingDate(LocalDateTime.now())
+            .build();
+
+        UserCommons userCommonsToSend = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(0)
+            .numOfCows(1)
+            .cowHealth(100)
+            .totalCowsBought(1)
+            .build();
+
+        UserCommons correctuserCommons = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(0)
+            .numOfCows(1)
+            .cowHealth(100)
+            .totalCowsBought(1)
+            .build();
+
+        String requestBody = mapper.writeValueAsString(userCommonsToSend);
+        String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+        when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
+
+        // act
+        MvcResult response = mockMvc.perform(put("/api/usercommons/buy?commonsId=1&numCows=0")
+            .contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8")
+            .content(requestBody)
+            .with(csrf()))
+            .andExpect(status().is(400)).andReturn();
+
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        String expectedString = "{\"message\":\"You need more money!\",\"type\":\"NotEnoughMoneyException\"}";
+        Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+        Map<String, Object> jsonResponse = responseToJson(response);
+        assertEquals(expectedJson, jsonResponse);
+    }
+    
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_SellCow_commons_exists_no_cow_to_sell() throws Exception {
+    
+        // arrange
+        UserCommons origUserCommons = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(300)
+            .numOfCows(0)
+            .cowHealth(100)
+            .totalCowsBought(0)
+            .build();
+
+        Commons testCommons = Commons
+            .builder()
+            .name("test commons")
+            .cowPrice(10)
+            .milkPrice(2)
+            .startingBalance(300)
+            .startingDate(LocalDateTime.now())
+            .build();
+
+        UserCommons userCommonsToSend = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(300)
+            .numOfCows(0)
+            .cowHealth(100)
+            .totalCowsBought(0)
+            .build();
+
+        UserCommons correctuserCommons = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(300)
+            .numOfCows(0)
+            .cowHealth(100)
+            .totalCowsBought(0)
+            .build();
+
+        String requestBody = mapper.writeValueAsString(userCommonsToSend);
+        String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+        when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
+
+        // act
+        MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=1&numCows=1")
+            .contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8")
+            .content(requestBody)
+            .with(csrf())).andExpect(status().is(400)).andReturn();
+
+
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        String expectedString = "{\"message\":\"You have no cows to sell!\",\"type\":\"NoCowsException\"}";
+        Map<String, Object> expectedJson = mapper.readValue(expectedString, Map.class);
+        Map<String, Object> jsonResponse = responseToJson(response);
+        assertEquals(expectedJson, jsonResponse);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_SellCow_commons_exists_user_sells_more_cows_than_owned() throws Exception {
+    
+        // arrange
+        UserCommons origUserCommons = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(300)
+            .numOfCows(3)
+            .cowHealth(100)
+            .totalCowsBought(3)
+            .build();
+
+        Commons testCommons = Commons
+            .builder()
+            .name("test commons")
+            .cowPrice(300)
+            .milkPrice(2)
+            .startingBalance(300)
+            .startingDate(LocalDateTime.now())
+            .build();
+
+        UserCommons userCommonsToSend = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(300)
+            .numOfCows(3)
+            .cowHealth(100)
+            .totalCowsBought(3)
+            .build();
+
+        UserCommons correctuserCommons = UserCommons
+            .builder()
+            .id(1L)
+            .userId(1L)
+            .commonsId(1L)
+            .totalWealth(1200)
+            .numOfCows(0)
+            .cowHealth(100)
+            .totalCowsBought(3)
+            .build();
+    
+        String requestBody = mapper.writeValueAsString(userCommonsToSend);
+        String expectedReturn = mapper.writeValueAsString(correctuserCommons);
+    
+        when(userCommonsRepository.findByCommonsIdAndUserId(eq(1L), eq(1L))).thenReturn(Optional.of(origUserCommons));
+        when(commonsRepository.findById(eq(1L))).thenReturn(Optional.of(testCommons));
+    
+        // act
+        MvcResult response = mockMvc.perform(put("/api/usercommons/sell?commonsId=1&numCows=10")
+            .contentType(MediaType.APPLICATION_JSON)
+            .characterEncoding("utf-8")
+            .content(requestBody)
+            .with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+    
+        // assert
+        verify(userCommonsRepository, times(1)).findByCommonsIdAndUserId(eq(1L), eq(1L));
+        verify(userCommonsRepository, times(1)).save(correctuserCommons);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedReturn, responseString);
+    }
 
 
     @WithMockUser(roles = { "USER" })
     @Test
     public void test_getAllUserCommonsById_exists() throws Exception {
-        List<UserCommons> expectedUserCommons = new ArrayList<UserCommons>();
-      UserCommons testexpectedUserCommons = dummyUserCommons(1);
-      expectedUserCommons.add(testexpectedUserCommons);
-      when(userCommonsRepository.findByCommonsId(eq(1L))).thenReturn(expectedUserCommons);
-  
-      MvcResult response = mockMvc.perform(get("/api/usercommons/commons/all?commonsId=1"))
-          .andExpect(status().isOk()).andReturn();
-  
-      verify(userCommonsRepository, times(1)).findByCommonsId(eq(1L));
-  
-      String expectedJson = mapper.writeValueAsString(expectedUserCommons);
-      String responseString = response.getResponse().getContentAsString();
-  
-      assertEquals(expectedJson, responseString);
+         List<UserCommons> expectedUserCommons = new ArrayList<UserCommons>();
+        UserCommons testexpectedUserCommons = dummyUserCommons(1);
+        expectedUserCommons.add(testexpectedUserCommons);
+        when(userCommonsRepository.findByCommonsId(eq(1L))).thenReturn(expectedUserCommons);
+    
+        MvcResult response = mockMvc.perform(get("/api/usercommons/commons/all?commonsId=1"))
+            .andExpect(status().isOk()).andReturn();
+    
+        verify(userCommonsRepository, times(1)).findByCommonsId(eq(1L));
+    
+        String expectedJson = mapper.writeValueAsString(expectedUserCommons);
+        String responseString = response.getResponse().getContentAsString();
+    
+        assertEquals(expectedJson, responseString);
     }
 
     @WithMockUser(roles = { "ADMIN" })
     @Test
     public void test_Admin_getAllUserCommonsById_exists() throws Exception {
         List<UserCommons> expectedUserCommons = new ArrayList<UserCommons>();
-      UserCommons testexpectedUserCommons = dummyUserCommons(1);
-      expectedUserCommons.add(testexpectedUserCommons);
-      when(userCommonsRepository.findByCommonsId(eq(1L))).thenReturn(expectedUserCommons);
-  
-      MvcResult response = mockMvc.perform(get("/api/usercommons/commons/all?commonsId=1"))
-          .andExpect(status().isOk()).andReturn();
-  
-      verify(userCommonsRepository, times(1)).findByCommonsId(eq(1L));
-  
-      String expectedJson = mapper.writeValueAsString(expectedUserCommons);
-      String responseString = response.getResponse().getContentAsString();
-  
-      assertEquals(expectedJson, responseString);
+        UserCommons testexpectedUserCommons = dummyUserCommons(1);
+        expectedUserCommons.add(testexpectedUserCommons);
+        when(userCommonsRepository.findByCommonsId(eq(1L))).thenReturn(expectedUserCommons);
+    
+        MvcResult response = mockMvc.perform(get("/api/usercommons/commons/all?commonsId=1"))
+            .andExpect(status().isOk()).andReturn();
+    
+        verify(userCommonsRepository, times(1)).findByCommonsId(eq(1L));
+    
+        String expectedJson = mapper.writeValueAsString(expectedUserCommons);
+        String responseString = response.getResponse().getContentAsString();
+    
+        assertEquals(expectedJson, responseString);
     }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -58,7 +58,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
   private ObjectMapper objectMapper;
 
   public static UserCommons dummyUserCommons(long id) {
-    UserCommons userCommons = new UserCommons(id,1,1,"test",1,1, 100);
+    UserCommons userCommons = new UserCommons(id,1,1,"test",1,1, 100,1);
     return userCommons;
   }
   @WithMockUser(roles = { "ADMIN" })
@@ -148,6 +148,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
       .build();
   
       Commons testCommons = Commons
@@ -167,6 +168,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -177,6 +179,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300-testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .totalCowsBought(2)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -214,6 +217,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
       .build();
   
       Commons testCommons = Commons
@@ -233,6 +237,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -243,6 +248,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(0)
       .numOfCows(2)
       .cowHealth(100)
+      .totalCowsBought(2)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -280,6 +286,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
       .build();
   
       Commons testCommons = Commons
@@ -299,6 +306,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -309,6 +317,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(0)
       .cowHealth(100)
+      .totalCowsBought(1)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -346,6 +355,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
       .build();
   
       Commons testCommons = Commons
@@ -365,6 +375,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -375,6 +386,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300-testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .totalCowsBought(2)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -414,6 +426,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
       .build();
   
       Commons testCommons = Commons
@@ -434,6 +447,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -444,6 +458,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .totalCowsBought(2)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -484,6 +499,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
       .build();
   
       Commons testCommons = Commons
@@ -503,6 +519,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -513,6 +530,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .totalCowsBought(2)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -551,6 +569,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
       .build();
   
       Commons testCommons = Commons
@@ -570,6 +589,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -580,6 +600,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .totalCowsBought(2)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -623,6 +644,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(0)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
       .build();
   
       Commons testCommons = Commons
@@ -642,6 +664,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(0)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -652,6 +675,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(0)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -690,6 +714,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(0)
       .cowHealth(100)
+      .totalCowsBought(0)
       .build();
   
       Commons testCommons = Commons
@@ -709,6 +734,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(0)
       .cowHealth(100)
+      .totalCowsBought(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -719,6 +745,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(0)
       .cowHealth(100)
+      .totalCowsBought(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);


### PR DESCRIPTION
In this PR, I added a new field, total cows bought, to the user commons model. Total cows bought is visible on the play page and leaderboard table.  Based on #22.

# Storybook

Before
* [LeaderboardTable](https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-4/storybook/?path=/story/components-leaderboard-leaderboardtable--five-user-commons)
* [FarmStats](https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-4/storybook/?path=/story/components-commons-farmstats--uncontrolled)

After
* [LeaderboardTable](https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-4/prs/24/storybook/?path=/story/components-leaderboard-leaderboardtable--five-user-commons)
* [FarmStats](https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-4/prs/24/storybook/?path=/story/components-commons-farmstats--uncontrolled)

# Screenshots

Before
<img width="579" alt="image" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-4/assets/77693393/630f0adc-91a2-4a62-9eeb-1a087beda426">
<img  alt="image" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-4/assets/77693393/703a25bd-57ec-4dbd-9417-81121321ec75">

After
<img width="579" alt="image" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-4/assets/77693393/f1760f2d-90e3-4090-9aa3-0bfdda3fe36b">
<img alt="image" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-4/assets/77693393/c49b3beb-63f7-4039-9097-ec8ad7c650c4">


