### PR TITLE
JessicaH - Redesign the user commons page (Make key user statistics clear)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,4 +1,5 @@
 body {
+    font-size: 20px;
     margin: 0;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
       'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
@@ -10,5 +11,14 @@ body {
   code {
     font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
       monospace;
+  }
+
+  .card-text.bigger-text {
+    font-size: 60px;
+  }
+
+  .icon.small {
+    width: 30px;
+    height: 30px;
   }
   

--- a/frontend/src/main/components/Commons/FarmStats.js
+++ b/frontend/src/main/components/Commons/FarmStats.js
@@ -10,15 +10,15 @@ const FarmStats = ({userCommons}) => {
         <Card.Body>
             {/* update total wealth and cow health with data from fixture */}
             <Card.Text>
-                <img className="icon" src={Cash} alt="Cash"></img>
+                <img className="icon small" src={Cash} alt="Cash"></img>
             </Card.Text>
-            <Card.Text>
+            <Card.Text className="bigger-text">
                 Total Wealth: ${userCommons.totalWealth}
             </Card.Text>
             <Card.Text>
-                <img className="icon" src={Health} alt="Health"></img> 
+                <img className="icon small" src={Health} alt="Health"></img> 
             </Card.Text>
-            <Card.Text>
+            <Card.Text className="bigger-text">
                 Cow Health: {Math.round(userCommons.cowHealth*100)/100}%
             </Card.Text>
         </Card.Body>

--- a/frontend/src/main/components/Commons/FarmStats.js
+++ b/frontend/src/main/components/Commons/FarmStats.js
@@ -5,7 +5,7 @@ import Cash from "./../../../assets/Cash.png";
 
 const FarmStats = ({userCommons}) => {
     return (
-        <Card>
+        <Card className="text-center">
         <Card.Header as="h5">Your Farm Stats</Card.Header>
         <Card.Body>
             {/* update total wealth and cow health with data from fixture */}


### PR DESCRIPTION
In this PR, I adjusted the text size bigger and icon size smaller to make stats clearer.
Before:
<img width="572" alt="Screen Shot 2023-05-31 at 5 29 49 PM" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-4/assets/81593198/a42378ff-658d-4224-8f09-5a0ffedc3ffd">



After:
<img width="577" alt="Screen Shot 2023-05-31 at 5 38 27 PM" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-4/assets/81593198/3b8163ab-e841-4c9b-ba0e-38d2a1e5eae9">

I was using this pr to see if the original code was fine. Will be centering text and making image a little bigger in the next pr.