### PR TITLE
JessicaH- Add day number on CommonsOverview

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,11 +14,11 @@ body {
   }
 
   .card-text.bigger-text {
-    font-size: 60px;
+    font-size: 50px;
   }
 
   .icon.small {
-    width: 30px;
-    height: 30px;
+    width: 50px;
+    height: 50px;
   }
   

--- a/frontend/src/main/components/Commons/CommonsOverview.js
+++ b/frontend/src/main/components/Commons/CommonsOverview.js
@@ -2,6 +2,7 @@ import React from "react";
 import { Row, Card, Col, Button } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
+import { calculateDays } from "main/utils/dayUtils";
 
 export default function CommonsOverview({ commons, currentUser }) {
 
@@ -9,6 +10,10 @@ export default function CommonsOverview({ commons, currentUser }) {
     // Stryker disable next-line all
     const leaderboardButtonClick = () => { navigate("/leaderboard/" + commons.id) };
     const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
+
+    //const startingDate = commons.startingDate;
+    commons.day = calculateDays(commons.startingDate);
+
     return (
         <Card data-testid="CommonsOverview">
             <Card.Header as="h5">Announcements</Card.Header>

--- a/frontend/src/main/components/Commons/CommonsOverview.js
+++ b/frontend/src/main/components/Commons/CommonsOverview.js
@@ -2,7 +2,7 @@ import React from "react";
 import { Row, Card, Col, Button } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
 import { hasRole } from "main/utils/currentUser";
-import { calculateDays } from "main/utils/dayUtils";
+import { calculateDays } from "main/utils/dateUtils";
 
 export default function CommonsOverview({ commons, currentUser }) {
 
@@ -11,8 +11,8 @@ export default function CommonsOverview({ commons, currentUser }) {
     const leaderboardButtonClick = () => { navigate("/leaderboard/" + commons.id) };
     const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
 
-    //const startingDate = commons.startingDate;
-    commons.day = calculateDays(commons.startingDate);
+    const today = new Date();
+    commons.day = calculateDays(commons.startingDate,today);
 
     return (
         <Card data-testid="CommonsOverview">

--- a/frontend/src/main/utils/dateUtils.js
+++ b/frontend/src/main/utils/dateUtils.js
@@ -11,7 +11,7 @@ const calculateDays = (startingDate,currentDate) => {
     const start = new Date(startingDate);
     const today = new Date(currentDate);
     const timeDifference = today.getTime() - start.getTime();
-    const days = Math.floor(timeDifference / (1000 * 3600 * 24));
+    const days = Math.floor(timeDifference / (1000 * 3600 * 24))+1;
     return days;
   }
 

--- a/frontend/src/main/utils/dateUtils.js
+++ b/frontend/src/main/utils/dateUtils.js
@@ -6,4 +6,13 @@ const timestampToDate = (timestamp) => {
     return (date.getFullYear() + "-" + (padWithZero(date.getMonth()+1)) + "-" + padWithZero(date.getDate()));
 }
 
-export {timestampToDate, padWithZero};
+
+const calculateDays = (startingDate,currentDate) => {
+    const start = new Date(startingDate);
+    const today = new Date(currentDate);
+    const timeDifference = today.getTime() - start.getTime();
+    const days = Math.floor(timeDifference / (1000 * 3600 * 24));
+    return days;
+  }
+
+export {timestampToDate, padWithZero, calculateDays};

--- a/frontend/src/main/utils/dayUtils.js
+++ b/frontend/src/main/utils/dayUtils.js
@@ -1,7 +1,0 @@
-export const calculateDays = (startingDate) => {
-    const start = new Date(startingDate);
-    const today = new Date();
-    const timeDifference = today.getTime() - start.getTime();
-    const days = Math.floor(timeDifference / (1000 * 3600 * 24));
-    return days;
-  };

--- a/frontend/src/main/utils/dayUtils.js
+++ b/frontend/src/main/utils/dayUtils.js
@@ -1,0 +1,7 @@
+export const calculateDays = (startingDate) => {
+    const start = new Date(startingDate);
+    const today = new Date();
+    const timeDifference = today.getTime() - start.getTime();
+    const days = Math.floor(timeDifference / (1000 * 3600 * 24));
+    return days;
+  };

--- a/frontend/src/tests/utils/dateUtils.test.js
+++ b/frontend/src/tests/utils/dateUtils.test.js
@@ -29,7 +29,7 @@ describe("dateUtils tests", () => {
     test("with mock current date 2023-06-01T00:00:00", () => {
       const startingDate = "2023-05-01T00:00:00";
       const currentDate = "2023-06-01T00:00:00";
-      expect(calculateDays(startingDate,currentDate)).toBe(31);
+      expect(calculateDays(startingDate,currentDate)).toBe(32);
 
     });
   });

--- a/frontend/src/tests/utils/dateUtils.test.js
+++ b/frontend/src/tests/utils/dateUtils.test.js
@@ -1,4 +1,4 @@
-import { padWithZero, timestampToDate } from "main/utils/dateUtils";
+import { padWithZero, timestampToDate, calculateDays} from "main/utils/dateUtils";
 
 
 describe("dateUtils tests", () => {
@@ -22,6 +22,15 @@ describe("dateUtils tests", () => {
   describe("timestampToDate tests", () => {
     it("converts properly", () => {
       expect(timestampToDate(1653346250816)).toBe("2022-05-23");
+    });
+  });
+
+  describe("calculateDays tests", () => {
+    test("with mock current date 2023-06-01T00:00:00", () => {
+      const startingDate = "2023-05-01T00:00:00";
+      const currentDate = "2023-06-01T00:00:00";
+      expect(calculateDays(startingDate,currentDate)).toBe(31);
+
     });
   });
 


### PR DESCRIPTION
This includes the code from my last PR for font change that has not been merged yet. Review only **CommonsOverview.js** and **dayUtils.js**

In this PR, I added a utility to calculate the number of days since the starting day. Previously, the commons.day is empty. The new function is called and assigned to this variable so that it displays the right day number in CommonsOverview. May be adding test cases and error messages for starting dates set the future, or maybe change so that admin cannot create a starting date beyond the current date.

# Storybook

* [Before](https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-4/storybook/?path=/story/components-commons-commonsoverview--uncontrolled)
* [After](https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-4/prs/15/storybook/?path=/story/components-commons-commonsoverview--uncontrolled)

# Screenshots
Before:
<img width="404" alt="Screen Shot 2023-06-01 at 3 05 09 PM" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-4/assets/81593198/4b599a6c-a50a-418b-bd15-8100f40d832e">

After:
<img width="423" alt="Screen Shot 2023-06-01 at 3 05 40 PM" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-4/assets/81593198/c7d61df8-822e-4630-8c01-f3a4e88bb8cc">
