### PR TITLE
Yuki - Update user commons and leaderboard fixtures to add totalCowsBought and totalCowsSold

### DIFF
--- a/frontend/src/fixtures/leaderboardFixtures.js
+++ b/frontend/src/fixtures/leaderboardFixtures.js
@@ -7,7 +7,10 @@ const leaderboardFixtures = {
             "username": "one",
             "commonsId": 1,
             "totalWealth" : 1000,
-            "numOfCows": 5
+            "cowHealth": 98.0,
+            "numOfCows": 5,
+            "totalCowsBought": 5,
+            "totalCowsSold": 1
         }
     ],
     threeUserCommonsLB:
@@ -18,7 +21,10 @@ const leaderboardFixtures = {
             "username": "one",
             "commonsId": 1,
             "totalWealth" : 1000,
-            "numOfCows": 8
+            "cowHealth": 38.0,
+            "numOfCows": 8,
+            "totalCowsBought": 45,
+            "totalCowsSold": 34
         },
         {
             "id":2,
@@ -26,7 +32,10 @@ const leaderboardFixtures = {
             "username": "two",
             "commonsId": 1,
             "totalWealth" : 1000,
-            "numOfCows": 5
+            "cowHealth": 55.0,
+            "numOfCows": 5,
+            "totalCowsBought": 28,
+            "totalCowsSold": 23
         },
         {
             "id":3,
@@ -34,7 +43,10 @@ const leaderboardFixtures = {
             "username": "three",
             "commonsId": 1,
             "totalWealth" : 100000,
-            "numOfCows": 1000
+            "cowHealth": 100.0,
+            "numOfCows": 1000,
+            "totalCowsBought": 1600,
+            "totalCowsSold": 300
         }
     ],
     fiveUserCommonsLB: 
@@ -46,7 +58,9 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "totalCowsBought": 10,
+            "totalCowsSold": 2
         },
         {
             "id":2,
@@ -55,7 +69,9 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "totalCowsBought": 11,
+            "totalCowsSold": 6
         },
         {
             "id":3,
@@ -64,7 +80,9 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "totalCowsBought": 1000,
+            "totalCowsSold": 0
         },
         {
             "id":4,
@@ -73,7 +91,9 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "totalCowsBought": 200,
+            "totalCowsSold": 100
         },
         {
             "id":5,
@@ -81,7 +101,10 @@ const leaderboardFixtures = {
             "username": "five",
             "commonsId": 1,
             "totalWealth" : 800,
-            "numOfCows": 60
+            "cowHealth": 65.0,
+            "numOfCows": 60,
+            "totalCowsBought": 88,
+            "totalCowsSold": 28
         }
     ],
     tenUserCommonsLB: 
@@ -93,7 +116,9 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "totalCowsBought": 88,
+            "totalCowsSold": 28
         },
         {
             "id":2,
@@ -102,7 +127,9 @@ const leaderboardFixtures = {
             "username": "two",
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "totalCowsBought": 15,
+            "totalCowsSold": 10
         },
         {
             "id":3,
@@ -111,7 +138,9 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "totalCowsBought": 1000,
+            "totalCowsSold": 0
         },
         {
             "id":4,
@@ -120,7 +149,9 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "totalCowsBought": 200,
+            "totalCowsSold": 100
         },
         {
             "id":5,
@@ -129,7 +160,9 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 800,
             "cowHealth": 72.0,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "totalCowsBought": 70,
+            "totalCowsSold": 3
         },
         {
             "id":6,
@@ -138,7 +171,9 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "totalCowsBought": 65,
+            "totalCowsSold": 45
         },
         {
             "id":7,
@@ -147,7 +182,9 @@ const leaderboardFixtures = {
             "commonsId": 1,
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "totalCowsBought": 8,
+            "totalCowsSold": 2
         },
         {
             "id":8,
@@ -156,7 +193,9 @@ const leaderboardFixtures = {
             "commonsId":  1,
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "totalCowsBought": 45,
+            "totalCowsSold": 8
         },
         {
             "id":9,
@@ -165,7 +204,9 @@ const leaderboardFixtures = {
             "commonsId":  1,
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "totalCowsBought": 99,
+            "totalCowsSold": 65
         },
         {
             "id":10,
@@ -173,7 +214,10 @@ const leaderboardFixtures = {
             "username": "ten",
             "commonsId": 1,
             "totalWealth" : 800,
-            "numOfCows": 60
+            "cowHealth": 98.0,
+            "numOfCows": 60,
+            "totalCowsBought": 99,
+            "totalCowsSold": 10
         }
     ]
 }

--- a/frontend/src/fixtures/userCommonsFixtures.js
+++ b/frontend/src/fixtures/userCommonsFixtures.js
@@ -20,7 +20,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "totalCowsBought": 100,
+            "totalCowsSold": 8
         }
     ],
     threeUserCommons:
@@ -44,7 +46,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "totalCowsBought": 100,
+            "totalCowsSold": 8
         },
         {
             "id":2,
@@ -65,7 +69,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "totalCowsBought": 200,
+            "totalCowsSold": 55
         },
         {
             "id":3,
@@ -86,7 +92,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "totalCowsBought": 300,
+            "totalCowsSold": 78
         }
     ],
     fiveUserCommons: 
@@ -110,7 +118,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "totalCowsBought": 100,
+            "totalCowsSold": 8
         },
         {
             "id":2,
@@ -131,7 +141,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "totalCowsBought": 200,
+            "totalCowsSold": 55
         },
         {
             "id":3,
@@ -152,7 +164,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "totalCowsBought": 300,
+            "totalCowsSold": 78
         },
         {
             "id":4,
@@ -173,7 +187,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "totalCowsBought": 200,
+            "totalCowsSold": 4
         },
         {
             "id":5,
@@ -194,7 +210,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 800,
             "cowHealth": 72.0,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "totalCowsBought": 89,
+            "totalCowsSold": 55
         }
     ],
     tenUserCommons: 
@@ -218,7 +236,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "totalCowsBought": 100,
+            "totalCowsSold": 8
         },
         {
             "id":2,
@@ -239,7 +259,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "totalCowsBought": 200,
+            "totalCowsSold": 55
         },
         {
             "id":3,
@@ -260,7 +282,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "totalCowsBought": 300,
+            "totalCowsSold": 78
         },
         {
             "id":4,
@@ -281,7 +305,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "totalCowsBought": 200,
+            "totalCowsSold": 4
         },
         {
             "id":5,
@@ -302,7 +328,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 800,
             "cowHealth": 72.0,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "totalCowsBought": 89,
+            "totalCowsSold": 55
         },
         {
             "id":6,
@@ -323,7 +351,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 93.0,
-            "numOfCows": 8
+            "numOfCows": 8,
+            "totalCowsBought": 10,
+            "totalCowsSold": 1
         },
         {
             "id":7,
@@ -344,7 +374,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 1000,
             "cowHealth": 98.0,
-            "numOfCows": 5
+            "numOfCows": 5,
+            "totalCowsBought": 89,
+            "totalCowsSold": 99
         },
         {
             "id":8,
@@ -365,7 +397,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 100000,
             "cowHealth": 2.0,
-            "numOfCows": 1000
+            "numOfCows": 1000,
+            "totalCowsBought": 1500,
+            "totalCowsSold": 55
         },
         {
             "id":9,
@@ -386,7 +420,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 50,
             "cowHealth": 84.0,
-            "numOfCows": 100
+            "numOfCows": 100,
+            "totalCowsBought": 201,
+            "totalCowsSold": 55
         },
         {
             "id":10,
@@ -407,7 +443,9 @@ const userCommonsFixtures = {
             },
             "totalWealth" : 800,
             "cowHealth": 72.0,
-            "numOfCows": 60
+            "numOfCows": 60,
+            "totalCowsBought": 100,
+            "totalCowsSold": 31
         }
     ]
 }


### PR DESCRIPTION
In this PR, I updated the user commons and leaderboard fixtures to add totalCowsBought and totalCowsSold. totalCowsBought and totalCowsSold fields will be implemented to the UserCommons entity in a future PR. I also added `cowHealth` to some objects in leaderboard fixtures.