### PR TITLE
pc - demo mocking date for CommonsOverview test

### DIFF
--- a/frontend/src/tests/components/Commons/CommonsOverview.test.js
+++ b/frontend/src/tests/components/Commons/CommonsOverview.test.js
@@ -81,9 +81,23 @@ describe("CommonsOverview tests", () => {
     });
  
     test("contains the correct content", async () => {
+
+        // arrange
+
+        jest.useFakeTimers().setSystemTime(new Date('2020-01-05'));
+
+        const commons = { 
+            ...commonsFixtures.oneCommons[0],
+            startingDate: new Date('2020-01-01'), 
+        };
+
+        // act
+
         render(
-            <CommonsOverview commons = {commonsFixtures.oneCommons[0]} />
+            <CommonsOverview commons = {commons} />
         );
+
+        // assert
 
         await waitFor (() => {
             expect(screen.getByText(/Today is day 5!/)).toBeInTheDocument();


### PR DESCRIPTION
This PR suggests a way to mock the date for the CommonsOverview test

Note that the test is still failing because the date calculation is how many days have passed since the start of the game, i.e. the first day of the game would be Day 0.

Is that what you want?  If not, perhaps you may want to change:

```js
 commons.day = calculateDays(commons.startingDate,today);
```

to:

```
 commons.day = calculateDays(commons.startingDate,today) + 1;
```