### PR TITLE
ab-Add GET /api/cowdeath/bycommons to CowDeathController - WIP

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CowDeathController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CowDeathController.java
@@ -1,0 +1,94 @@
+package edu.ucsb.cs156.happiercows.controllers;
+
+import edu.ucsb.cs156.happiercows.entities.CowDeath;
+import edu.ucsb.cs156.happiercows.repositories.CowDeathRepository;
+import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
+import edu.ucsb.cs156.happiercows.errors.NoCowsException;  
+import edu.ucsb.cs156.happiercows.models.CurrentUser;
+import edu.ucsb.cs156.happiercows.entities.Profit;
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.ProfitRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.models.CreateCowDeathParams;
+
+import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
+
+import java.time.ZonedDateTime;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Iterator;
+import java.util.*;
+import java.util.stream.*;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@Slf4j
+@Api(description = "CowDeath")
+@RequestMapping("/api/cowdeath")
+@RestController
+
+public class CowDeathController extends ApiController {
+
+    @Autowired
+    CommonsRepository commonsRepository;
+
+    @Autowired
+    UserCommonsRepository userCommonsRepository;
+
+    @Autowired
+    CowDeathRepository cowDeathRepository;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @ApiOperation(value = "Takes a commonsId and lists all cow casualities for that commons")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/bycommons")
+    public Iterable<CowDeath> allCowDeathbyCommonsId(
+            @ApiParam("commonsId") @RequestParam Long commonsId) {
+        
+        List<UserCommons> userCommonsList = new ArrayList<>();
+        userCommonsRepository.findByCommonsId(commonsId).forEach(userCommonsList::add);
+
+        if (userCommonsList.isEmpty()) {
+        throw new EntityNotFoundException(UserCommons.class,"commonsId");
+        }
+
+        UserCommons userCommons = userCommonsList.get(0);
+        Iterable<CowDeath> allCowDeathbyCommonsId = cowDeathRepository.findAllByUserCommons_Id(userCommons.getId());
+
+        List<CowDeath> savedCowDeaths = new ArrayList<>();
+        allCowDeathbyCommonsId.forEach(cowDeath -> savedCowDeaths.add(cowDeathRepository.save(cowDeath)));
+
+        return savedCowDeaths;
+    }
+
+    
+    
+}
+

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/CowDeath.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/CowDeath.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.happiercows.entities;
 
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 import javax.persistence.*;
 
@@ -9,7 +10,6 @@ import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.AccessLevel;
-
 
 
 @Data
@@ -21,10 +21,8 @@ public class CowDeath {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long id;
-
   @Column(name="commons_id")
   private long commonsId;
-
   @Column(name="user_id")
   private long userId;
   
@@ -32,4 +30,28 @@ public class CowDeath {
   private Integer cowsKilled; 
   private double avgHealth; 
 
+  public LocalDateTime getZonedDateTime() {
+    return zonedDateTime;
+  }
+
+  public void setZonedDateTime(LocalDateTime zonedDateTime) {
+    this.zonedDateTime = zonedDateTime;
+  }
+
+  public Integer getCowsKilled() {
+    return cowsKilled;
+  }
+
+  public void setCowsKilled(Integer cowsKilled) {
+    this.cowsKilled = cowsKilled;
+  }
+
+  public double getAvgHealth() {
+    return avgHealth;
+  }
+
+  public void setAvgHealth(double avgHealth) {
+    this.avgHealth = avgHealth;
+
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCowDeathParams.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCowDeathParams.java
@@ -1,0 +1,44 @@
+package edu.ucsb.cs156.happiercows.models;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.Collection;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import org.springframework.format.annotation.NumberFormat;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import org.springframework.security.core.GrantedAuthority;
+
+import edu.ucsb.cs156.happiercows.entities.User;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor (access = AccessLevel.PROTECTED)
+@Builder
+public class CreateCowDeathParams {
+  @DateTimeFormat
+  private LocalDateTime zonedDateTime;
+  @NumberFormat
+  private Integer cowsKilled;
+  @NumberFormat
+  private double avgHealth;
+
+  public LocalDateTime getZonedDateTime() {
+    return zonedDateTime;
+  }
+
+  public Integer getcowsKilled() {
+    return cowsKilled;
+  }
+
+  public double getavgHealth() {
+    return avgHealth;
+  }
+
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/CowDeathRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/CowDeathRepository.java
@@ -7,5 +7,5 @@ import edu.ucsb.cs156.happiercows.entities.CowDeath;
 
 @Repository
 public interface CowDeathRepository extends CrudRepository<CowDeath, Long> {
-    
+      Iterable<CowDeath> findAllByUserCommons_Id(long userCommonsId);  
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CowDeathControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CowDeathControllerTests.java
@@ -1,0 +1,147 @@
+package edu.ucsb.cs156.happiercows.controllers;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.time.ZonedDateTime;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.springframework.test.web.servlet.MockMvc;
+
+
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.cs156.happiercows.ControllerTestCase;
+import edu.ucsb.cs156.happiercows.entities.Commons;
+
+import edu.ucsb.cs156.happiercows.entities.CowDeath;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
+import edu.ucsb.cs156.happiercows.models.CreateCowDeathParams;
+import edu.ucsb.cs156.happiercows.repositories.CowDeathRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import static org.mockito.ArgumentMatchers.*;
+
+@WebMvcTest(controllers = CowDeathController.class)
+@AutoConfigureDataJpa
+public class CowDeathControllerTests extends ControllerTestCase{
+
+    @Autowired
+    private MockMvc mockMvc;
+
+   @MockBean
+   UserCommonsRepository userCommonsRepository;
+
+   @MockBean
+   UserRepository userRepository;
+
+   @MockBean
+   CommonsRepository commonsRepository;
+
+   @MockBean
+   CowDeathRepository cowDeathRepository;
+
+   @Autowired
+   private ObjectMapper objectMapper;
+
+    @WithMockUser(roles = {"ADMIN"})
+    /*
+    @Test
+      public void testAllCowDeathByCommonsId() throws Exception {
+        Long commonsId = 1L;
+
+        UserCommons userCommons = UserCommons.builder().id(1L).build();
+        
+
+        List<UserCommons> userCommonsList = new ArrayList<>();
+        userCommonsList.add(userCommons);
+
+        when(userCommonsRepository.findByCommonsId(eq(commonsId))).thenReturn(userCommonsList);
+
+        Iterable<CowDeath> cowDeaths = new ArrayList<>();
+        when(cowDeathRepository.findAllByUserCommons_Id(eq(userCommons.getId()))).thenReturn(cowDeaths);
+
+        mockMvc.perform(get("/api/cowdeath/bycommons")
+                .param("commonsId", String.valueOf(commonsId)))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(cowDeaths)))
+                .andReturn();
+
+        verify(cowDeathRepository, times(1)).save(any(CowDeath.class));
+
+       
+        Iterable<CowDeath> receivedCowDeaths = cowDeathRepository.findAllByUserCommons_Id(eq(userCommons.getId())); 
+        
+        verify(userCommonsRepository, times(1)).findByCommonsId(eq(commonsId));
+        verify(cowDeathRepository, times(1)).findAllByUserCommons_Id(eq(userCommons.getId()));
+    }
+
+    */
+    @Test
+    public void testAllCowDeathByCommonsId() throws Exception {
+        Long commonsId = 1L;
+
+        UserCommons userCommons = UserCommons.builder()
+            .id(1L)
+            .build();
+
+        List<UserCommons> userCommonsList = new ArrayList<>();
+        userCommonsList.add(userCommons);
+
+        when(userCommonsRepository.findByCommonsId(eq(commonsId))).thenReturn(userCommonsList);
+
+        Iterable<CowDeath> cowDeaths = new ArrayList<>();
+        when(cowDeathRepository.findAllByUserCommons_Id(eq(userCommons.getId()))).thenReturn(cowDeaths);
+
+        MvcResult result = mockMvc.perform(get("/api/cowdeath/bycommons")
+                .param("commonsId", String.valueOf(commonsId)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String jsonResponse = result.getResponse().getContentAsString();
+        Iterable<CowDeath> receivedCowDeaths = objectMapper.readValue(jsonResponse, new TypeReference<Iterable<CowDeath>>() {});
+
+        // Verify that the create method saves the cowDeath
+        verify(cowDeathRepository, times(1)).save(any(CowDeath.class));
+
+        // Compare the cowDeaths and receivedCowDeaths
+        assertEquals(cowDeaths, receivedCowDeaths);
+
+        verify(userCommonsRepository, times(1)).findByCommonsId(eq(commonsId));
+        verify(cowDeathRepository, times(1)).findAllByUserCommons_Id(eq(userCommons.getId()));
+        }
+
+
+}


### PR DESCRIPTION
In this WIP PR, I added the second of three routes to the CowDeathController file. This PR was the second route, GET /api/cowdeath/bycommons that takes a commons id, and lists all cow casualties for that commons.