### PR TITLE
Yuki - Add total cows bought and sold to leaderboard table

### DIFF
--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -25,6 +25,14 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
             Header: 'Cow Health',
             accessor: 'cowHealth', 
         },
+        {
+            Header: 'Total Cows Bought',
+            accessor: 'totalCowsBought', 
+        },
+        {
+            Header: 'Total Cows Sold',
+            accessor: 'totalCowsSold', 
+        },
     ];
 
     const testid = "LeaderboardTable";

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -65,8 +65,8 @@ describe("LeaderboardTable tests", () => {
 
     );
 
-    const expectedHeaders = ['(Admin) userCommons Id', 'Username', 'User Id', 'Total Wealth', 'Cows Owned', 'Cow Health'];
-    const expectedFields = ['id', 'userId', 'username', 'totalWealth','numOfCows', 'cowHealth'];
+    const expectedHeaders = ['(Admin) userCommons Id', 'Username', 'User Id', 'Total Wealth', 'Cows Owned', 'Cow Health', 'Total Cows Bought', 'Total Cows Sold'];
+    const expectedFields = ['id', 'userId', 'username', 'totalWealth','numOfCows', 'cowHealth', 'totalCowsBought', 'totalCowsSold'];
     const testId = "LeaderboardTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -83,11 +83,56 @@ describe("LeaderboardTable tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-0-col-userId`)).toHaveTextContent("1");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-username`)).toHaveTextContent("one");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-totalWealth`)).toHaveTextContent("1000");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-totalCowsBought`)).toHaveTextContent("45");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-totalCowsSold`)).toHaveTextContent("34");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-userId`)).toHaveTextContent("2");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-username`)).toHaveTextContent("two");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-totalWealth`)).toHaveTextContent("1000");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-totalCowsBought`)).toHaveTextContent("28");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-totalCowsSold`)).toHaveTextContent("23");
 
+  });
+
+  test("Has the expected column headers and content for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <LeaderboardTable leaderboardUsers={leaderboardFixtures.threeUserCommonsLB} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    const expectedHeaders = ['User Id', 'Username', 'Total Wealth', 'Cows Owned', 'Cow Health', 'Total Cows Bought', 'Total Cows Sold'];
+    const expectedFields = ['userId', 'username', 'totalWealth','numOfCows', 'cowHealth', 'totalCowsBought', 'totalCowsSold'];
+    const testId = "LeaderboardTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    const userCommonsIDHeader = screen.queryByText('(Admin) userCommons Id');
+    expect(userCommonsIDHeader).not.toBeInTheDocument();
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-userId`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-username`)).toHaveTextContent("one");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-totalWealth`)).toHaveTextContent("1000");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-totalCowsBought`)).toHaveTextContent("45");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-totalCowsSold`)).toHaveTextContent("34");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-userId`)).toHaveTextContent("2");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-username`)).toHaveTextContent("two");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-totalWealth`)).toHaveTextContent("1000");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-totalCowsBought`)).toHaveTextContent("28");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-totalCowsSold`)).toHaveTextContent("23");
   });
 
 });

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -190,6 +190,8 @@ public class CommonsController extends ApiController {
         .totalWealth(joinedCommons.getStartingBalance())
         .numOfCows(0)
         .cowHealth(100)
+        .totalCowsBought(0)
+        .totalCowsSold(0)
         .build();
 
     userCommonsRepository.save(uc);

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -116,6 +116,7 @@ public class UserCommonsController extends ApiController {
         if(userCommons.getTotalWealth() >= commons.getCowPrice() ){
           userCommons.setTotalWealth(userCommons.getTotalWealth() - commons.getCowPrice());
           userCommons.setNumOfCows(userCommons.getNumOfCows() + 1);
+          userCommons.setTotalCowsBought(userCommons.getTotalCowsBought() + 1);
         }
         else{
           throw new NotEnoughMoneyException("You need more money!");
@@ -144,6 +145,7 @@ public class UserCommonsController extends ApiController {
         if(userCommons.getNumOfCows() >= 1 ){
           userCommons.setTotalWealth(userCommons.getTotalWealth() + commons.getCowPrice());
           userCommons.setNumOfCows(userCommons.getNumOfCows() - 1);
+          userCommons.setTotalCowsSold(userCommons.getTotalCowsSold() + 1);
         }
         else{
           throw new NoCowsException("You have no cows to sell!");

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -472,6 +472,8 @@ public class CommonsControllerTests extends ControllerTestCase {
         .totalWealth(0)
         .numOfCows(0)
         .cowHealth(100)
+        .totalCowsBought(0)
+        .totalCowsSold(0)
         .build();
 
     UserCommons ucSaved = UserCommons.builder()
@@ -482,6 +484,8 @@ public class CommonsControllerTests extends ControllerTestCase {
         .totalWealth(0)
         .numOfCows(0)
         .cowHealth(100)
+        .totalCowsBought(0)
+        .totalCowsSold(0)
         .build();
 
     String requestBody = mapper.writeValueAsString(uc);

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -182,7 +182,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(280)
       .numOfCows(3)
       .cowHealth(100)
-      .totalCowsBought(2)
+      .totalCowsBought(3)
       .totalCowsSold(0)
       .build();
   

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -149,6 +149,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -168,6 +170,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -178,6 +182,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300-testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .totalCowsBought(2)
+      .totalCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -215,6 +221,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -234,6 +242,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -244,6 +254,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(0)
       .numOfCows(2)
       .cowHealth(100)
+      .totalCowsBought(2)
+      .totalCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -281,6 +293,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -300,6 +314,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -310,6 +326,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(0)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(1)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -347,6 +365,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -366,6 +386,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -376,6 +398,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300-testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -415,6 +439,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -435,6 +461,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -445,6 +473,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -485,6 +515,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -504,6 +536,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -514,6 +548,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -552,6 +588,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -571,6 +609,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -581,6 +621,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -624,6 +666,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(0)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -643,6 +687,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(0)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -653,6 +699,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(0)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -691,6 +739,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(0)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -710,6 +760,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(0)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -720,6 +772,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(0)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);


### PR DESCRIPTION
In this PR, total cows bought and sold is visible on the leaderboard table.  Branched off #51.

# Storybook

Before
* [LeaderboardTable](https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-4/storybook/?path=/story/components-leaderboard-leaderboardtable--five-user-commons)

After
* [LeaderboardTable](https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-4/prs/74/storybook/?path=/story/components-leaderboard-leaderboardtable--five-user-commons)

# Screenshots

Before
<img width="579" alt="image" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-4/assets/77693393/630f0adc-91a2-4a62-9eeb-1a087beda426">

After
<img width="579" alt="image" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-4/assets/77693393/f350ed1e-466c-4e95-9386-9a7bd514269d">

