### PR TITLE
JacobW Sell All Cows Button

### DIFF
--- a/frontend/src/main/components/Commons/ManageCows.js
+++ b/frontend/src/main/components/Commons/ManageCows.js
@@ -28,6 +28,7 @@ const ManageCows = ({userCommons,commons, onBuy, onSell}) =>  {
                         <br/>
                         <br/>
                         <Button variant="outline-danger" onClick={()=>{onSell(userCommons, 10)}} data-testid={"sell-10-cows-button"}>Sell ten cows</Button>
+                        <Button variant="outline-danger" onClick={()=>{onSell(userCommons, userCommons.numOfCows)}} data-testid={"sell-all-cows-button"}>Sell all cows</Button>
                         <br/>
                         <br/>
                     </Col>

--- a/frontend/src/tests/components/Commons/ManageCows.test.js
+++ b/frontend/src/tests/components/Commons/ManageCows.test.js
@@ -21,6 +21,7 @@ describe("ManageCows tests", () => {
         const buyButton = screen.getByTestId("buy-cow-button");
         const sellButton = screen.getByTestId("sell-cow-button");
         const sell10Button = screen.getByTestId("sell-10-cows-button");
+        const sellAllButton = screen.getByTestId("sell-all-cows-button");
         
         fireEvent.click(buy10Button);
         await waitFor( ()=>expect(mockBuy).toHaveBeenCalled() );
@@ -32,6 +33,7 @@ describe("ManageCows tests", () => {
         await waitFor( ()=>expect(mockSell).toHaveBeenCalled() );
 
         fireEvent.click(sell10Button);
+        fireEvent.click(sellAllButton);
         await waitFor( ()=>expect(mockSell).toHaveBeenCalled() );
         
     });

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -143,12 +143,33 @@ describe("PlayPage tests", () => {
             </QueryClientProvider>
         );
 
-        const sellCowButton = screen.getByTestId("sell-10-cows-button");
-        fireEvent.click(sellCowButton);
+        const sell10CowButtons = screen.getByTestId("sell-10-cows-button");
+        fireEvent.click(sell10CowButtons);
 
         await waitFor(() => expect(axiosMock.history.put.length).toBe(1));
         
         expect(axiosMock.history.put[0].params).toEqual({ commonsId: 1, numCows: 10 });
+        expect(mockToast).toBeCalledWith(`Cow sold!`);
+
+    });
+
+    test("click sell all button", async () => {
+        axiosMock.onPut("/api/usercommons/sell").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlayPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        const sellAllCowsButton = screen.getByTestId("sell-all-cows-button");
+        fireEvent.click(sellAllCowsButton);
+
+        await waitFor(() => expect(axiosMock.history.put.length).toBe(1));
+        
+        expect(axiosMock.history.put[0].params).toEqual({ commonsId: 1, numCows: 5 });
         expect(mockToast).toBeCalledWith(`Cow sold!`);
 
     });


### PR DESCRIPTION
This PR is based on #72 adds a button in ManageCows.js that sells all your cows, and adds relevent tests in ManageCows.test.js and PlayPage.test.js.

# Storybook:
Before:
* [ManageCows](https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-4/storybook/?path=/story/components-commons-managecows--uncontrolled)

After:
* [ManageCows](https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-4/prs/76/storybook/?path=/story/components-commons-managecows--uncontrolled)

# Screenshots:
Before:
![Screenshot 2023-06-07 165620](https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-4/assets/129801356/1495cd76-aea5-4507-bfca-a6987967609b)
After:
![Screenshot 2023-06-07 165700](https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-4/assets/129801356/7244f364-0ab0-46a2-9aaa-a1051d7e89c4)
