### PR TITLE
Yuki - Add total cows bought and sold to FarmStats

### DIFF
--- a/frontend/src/main/components/Commons/FarmStats.js
+++ b/frontend/src/main/components/Commons/FarmStats.js
@@ -21,6 +21,12 @@ const FarmStats = ({userCommons}) => {
             <Card.Text className="bigger-text">
                 Cow Health: {Math.round(userCommons.cowHealth*100)/100}%
             </Card.Text>
+            <Card.Text>
+                Total Cows Bought: {userCommons.totalCowsBought}
+            </Card.Text>
+            <Card.Text>
+                Total Cows Sold: {userCommons.totalCowsSold}
+            </Card.Text>
         </Card.Body>
         </Card>
     ); 

--- a/frontend/src/tests/components/Commons/FarmStats.test.js
+++ b/frontend/src/tests/components/Commons/FarmStats.test.js
@@ -19,6 +19,8 @@ describe("FarmStats tests", () => {
         }); 
 
         expect(screen.getByText(/Cow Health: 98%/)).toBeInTheDocument();
+        expect(screen.getByText(/Total Cows Bought: 100/)).toBeInTheDocument();
+        expect(screen.getByText(/Total Cows Sold: 8/)).toBeInTheDocument();
 
     });
 });

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -190,6 +190,8 @@ public class CommonsController extends ApiController {
         .totalWealth(joinedCommons.getStartingBalance())
         .numOfCows(0)
         .cowHealth(100)
+        .totalCowsBought(0)
+        .totalCowsSold(0)
         .build();
 
     userCommonsRepository.save(uc);

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsController.java
@@ -116,6 +116,7 @@ public class UserCommonsController extends ApiController {
         if(userCommons.getTotalWealth() >= commons.getCowPrice() ){
           userCommons.setTotalWealth(userCommons.getTotalWealth() - commons.getCowPrice());
           userCommons.setNumOfCows(userCommons.getNumOfCows() + 1);
+          userCommons.setTotalCowsBought(userCommons.getTotalCowsBought() + 1);
         }
         else{
           throw new NotEnoughMoneyException("You need more money!");
@@ -144,6 +145,7 @@ public class UserCommonsController extends ApiController {
         if(userCommons.getNumOfCows() >= 1 ){
           userCommons.setTotalWealth(userCommons.getTotalWealth() + commons.getCowPrice());
           userCommons.setNumOfCows(userCommons.getNumOfCows() - 1);
+          userCommons.setTotalCowsSold(userCommons.getTotalCowsSold() + 1);
         }
         else{
           throw new NoCowsException("You have no cows to sell!");

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -472,6 +472,8 @@ public class CommonsControllerTests extends ControllerTestCase {
         .totalWealth(0)
         .numOfCows(0)
         .cowHealth(100)
+        .totalCowsBought(0)
+        .totalCowsSold(0)
         .build();
 
     UserCommons ucSaved = UserCommons.builder()
@@ -482,6 +484,8 @@ public class CommonsControllerTests extends ControllerTestCase {
         .totalWealth(0)
         .numOfCows(0)
         .cowHealth(100)
+        .totalCowsBought(0)
+        .totalCowsSold(0)
         .build();
 
     String requestBody = mapper.writeValueAsString(uc);

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -182,7 +182,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(280)
       .numOfCows(3)
       .cowHealth(100)
-      .totalCowsBought(2)
+      .totalCowsBought(3)
       .totalCowsSold(0)
       .build();
   

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -149,6 +149,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -168,6 +170,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -178,6 +182,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300-testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .totalCowsBought(2)
+      .totalCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -215,6 +221,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -234,6 +242,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -244,6 +254,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(0)
       .numOfCows(2)
       .cowHealth(100)
+      .totalCowsBought(2)
+      .totalCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -281,6 +293,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -300,6 +314,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -310,6 +326,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(0)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(1)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -347,6 +365,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -366,6 +386,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -376,6 +398,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300-testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -415,6 +439,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -435,6 +461,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -445,6 +473,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -485,6 +515,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -504,6 +536,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -514,6 +548,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -552,6 +588,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -571,6 +609,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -581,6 +621,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300+testCommons.getCowPrice())
       .numOfCows(2)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -624,6 +666,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(0)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -643,6 +687,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(0)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -653,6 +699,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(0)
       .numOfCows(1)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);
@@ -691,6 +739,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(0)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       Commons testCommons = Commons
@@ -710,6 +760,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(0)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       UserCommons correctuserCommons = UserCommons
@@ -720,6 +772,8 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       .totalWealth(300)
       .numOfCows(0)
       .cowHealth(100)
+      .totalCowsBought(1)
+      .totalCowsSold(0)
       .build();
   
       String requestBody = mapper.writeValueAsString(userCommonsToSend);


### PR DESCRIPTION
In this PR, total cows bought and total cows sold fields are visible under "Your Farm Stats" column in the play page. Branched off PR #51.

Before
* [FarmStats](https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-4/storybook/?path=/story/components-commons-farmstats--uncontrolled)

After
* [FarmStats](https://ucsb-cs156-s23.github.io/proj-happycows-s23-6pm-4/prs/77/storybook/?path=/story/components-commons-farmstats--uncontrolled)

Before
<img  alt="image" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-4/assets/77693393/703a25bd-57ec-4dbd-9417-81121321ec75">

After
<img alt="image" src="https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-4/assets/77693393/018343af-9373-4756-9165-075e8df9cadd">


