### PR TITLE
JessicaH- Function to calc total players

### DIFF
--- a/frontend/src/main/utils/leaderboardSortingUtils.js
+++ b/frontend/src/main/utils/leaderboardSortingUtils.js
@@ -17,3 +17,9 @@ export function sortByCowHealth(userCommonsArray, returnArraySize = userCommonsA
     return b.cowHealth - a.cowHealth;
   }).slice(0, returnArraySize);
 }
+
+export function getPlayerNum(userCommonsArray) {
+  if (userCommonsArray.length==null){return 0;}
+  
+  return userCommonsArray.length;
+}

--- a/frontend/src/main/utils/leaderboardSortingUtils.js
+++ b/frontend/src/main/utils/leaderboardSortingUtils.js
@@ -21,5 +21,5 @@ export function sortByCowHealth(userCommonsArray, returnArraySize = userCommonsA
 export function getPlayerNum(userCommonsArray) {
   if (userCommonsArray.length==null){return 0;}
   
-  return userCommonsArray.length;
+  return userCommonsArray.length; 
 }

--- a/frontend/src/tests/utils/leaderboardSortingUtils.test.js
+++ b/frontend/src/tests/utils/leaderboardSortingUtils.test.js
@@ -135,7 +135,7 @@ describe("leaderboardSortingUtils tests", () => {
     const totalPlayers = getPlayerNum(tenUserCommons);
     const expectedPlayers = 10;
     
-    expect(totalPlayers).toBe(expectedPlayers);
+    expect(totalPlayers).toBe(expectedPlayers); 
   });
 
 })

--- a/frontend/src/tests/utils/leaderboardSortingUtils.test.js
+++ b/frontend/src/tests/utils/leaderboardSortingUtils.test.js
@@ -1,4 +1,4 @@
-import { sortByWealth, sortByNumCows, sortByCowHealth } from "../../main/utils/leaderboardSortingUtils"
+import { sortByWealth, sortByNumCows, sortByCowHealth, getPlayerNum } from "../../main/utils/leaderboardSortingUtils"
 import userCommonsFixtures from "../../fixtures/userCommonsFixtures"
 
 describe("leaderboardSortingUtils tests", () => {
@@ -120,5 +120,22 @@ describe("leaderboardSortingUtils tests", () => {
     }
   });
 
+
+  //-----------------------------//
+  //      Total Player Tests
+  //----------------------------//
+
+  test("getPlayerNum for fiveUserCommons", () => {
+    const totalPlayers = getPlayerNum(fiveUserCommons);
+    const expectedPlayers = 5;
+    
+    expect(totalPlayers).toBe(expectedPlayers);
+  });
+  test("getPlayerNum for tenUserCommons", () => {
+    const totalPlayers = getPlayerNum(tenUserCommons);
+    const expectedPlayers = 10;
+    
+    expect(totalPlayers).toBe(expectedPlayers);
+  });
 
 })


### PR DESCRIPTION
In this PR, I added a function to find the total player number in each common. This only works on the LeaderboardFixtures right now and have been tested.

Will get the number onto CommonsOverview in the next commit.