### PR TITLE
Fixed bug relating to local host images from PR 69

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/FrontendProxyController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/FrontendProxyController.java
@@ -13,7 +13,7 @@ import java.net.ConnectException;
 @RestController
 public class FrontendProxyController {
   @GetMapping({"/", "/{path:^(?!api|oauth2|swagger-ui).*}/**"})
-  public ResponseEntity<?> proxy(ProxyExchange<Integer> proxy) {
+  public ResponseEntity<?> proxy(ProxyExchange<byte[]> proxy) {
     String path = proxy.path("/");
     try {
       return proxy.uri("http://localhost:3000/" + path).get();


### PR DESCRIPTION
There was some error on the admin side (maybe because of the variable type I used so I switched to an array and that fixed the issue)