### PR TITLE
JessicaL - ProfilePage displays Column Style

### DIFF
--- a/frontend/src/main/pages/ProfilePage.js
+++ b/frontend/src/main/pages/ProfilePage.js
@@ -18,7 +18,7 @@ const ProfilePage = () => {
     const { email, pictureUrl, fullName } = currentUser.root.user;
     return (
         <BasicLayout>
-            <Row className="align-items-center profile-header mb-5 text-center text-md-left">
+            <Row className="profile-header mb-5 text-center text-md-left">
                 <Col md={2}>
                     <img
                         src={pictureUrl}
@@ -32,7 +32,7 @@ const ProfilePage = () => {
                     <RoleBadge role={"ROLE_ADMIN"} currentUser={currentUser}/>
                 </Col>
                 <Col>
-                    <ReactJson src={currentUser.root} />
+                    <ReactJson src={currentUser.root.user.commons} />
                 </Col>
             </Row>
         </BasicLayout>

--- a/frontend/src/main/pages/ProfilePage.js
+++ b/frontend/src/main/pages/ProfilePage.js
@@ -25,17 +25,15 @@ const ProfilePage = () => {
                         alt="Profile"
                         className="rounded-circle img-fluid profile-picture mb-3 mb-md-0"
                     />
-                </Col>
-                <Col md>
                     <h2>{fullName}</h2>
                     <p className="lead text-muted">{email}</p>
                     <RoleBadge role={"ROLE_USER"} currentUser={currentUser}/>
                     <RoleBadge role={"ROLE_MEMBER"} currentUser={currentUser}/>
                     <RoleBadge role={"ROLE_ADMIN"} currentUser={currentUser}/>
                 </Col>
-            </Row>
-            <Row className="text-left">
-                <ReactJson src={currentUser.root} />
+                <Col>
+                    <ReactJson src={currentUser.root} />
+                </Col>
             </Row>
         </BasicLayout>
     );

--- a/frontend/src/main/pages/ProfilePage.js
+++ b/frontend/src/main/pages/ProfilePage.js
@@ -18,8 +18,8 @@ const ProfilePage = () => {
     const { email, pictureUrl, fullName } = currentUser.root.user;
     return (
         <BasicLayout>
-            <Row className="profile-header mb-5 text-center text-md-left">
-                <Col md={2}>
+            <Row className="profile-header mb-5">
+                <Col md={3} className="text-center">
                     <img
                         src={pictureUrl}
                         alt="Profile"
@@ -31,7 +31,7 @@ const ProfilePage = () => {
                     <RoleBadge role={"ROLE_MEMBER"} currentUser={currentUser}/>
                     <RoleBadge role={"ROLE_ADMIN"} currentUser={currentUser}/>
                 </Col>
-                <Col>
+                <Col className="text-md-left">
                     <ReactJson src={currentUser.root.user.commons} />
                 </Col>
             </Row>

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -85,7 +85,7 @@ describe("PlayPage tests", () => {
 
         await waitFor(() => expect(axiosMock.history.put.length).toBe(1));
 
-        expect(axiosMock.history.put[0].params).toEqual({ commonsId: 1 });
+        expect(axiosMock.history.put[0].params).toEqual({ commonsId: 1, numCows: 1 });
         expect(mockToast).toBeCalledWith(`Cow bought!`);
 
     });


### PR DESCRIPTION
In this PR, instead of making the Profile Page display in a row style, it's instead in a column style. In addition, since all the information like name, email, and roles from root are already displayed, it displays only the commons that the user is in.

# Storybook
Storybook for ProfilePage does not exist

# Screenshots
Before:
![image](https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-4/assets/70113987/348a76f7-26bd-4273-b699-2a39e1fc04f4)
After:
![image](https://github.com/ucsb-cs156-s23/proj-happycows-s23-6pm-4/assets/70113987/b505eaeb-e0d9-4c0c-99d2-3f9d786cf86b)